### PR TITLE
Re-order / Edit / Delete / Select Hotkeys

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -181,53 +181,53 @@
                   <div class="card-body">
                     <div id="hotkey-tab-content" class="tab-content">
                     <ul class="list-group list-group-flush tab-pane fade show active hotkeys" id="hotkeys_list_1" role="tabpanel">
-                      <li class="list-group-item text-nowrap p-1" id="f1_hotkey">
+                      <li class="list-group-item text-nowrap unselectable" id="f1_hotkey">
                         <div class="badge badge-dark">F1</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f2_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f2_hotkey" >
                         <div class="badge badge-dark">F2</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f3_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f3_hotkey" >
                         <div class="badge badge-dark">F3</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f4_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f4_hotkey" >
                         <div class="badge badge-dark">F4</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f5_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f5_hotkey" >
                         <div class="badge badge-dark">F5</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f6_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f6_hotkey" >
                         <div class="badge badge-dark">F6</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f7_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f7_hotkey" >
                         <div class="badge badge-dark">F7</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f8_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f8_hotkey" >
                         <div class="badge badge-dark">F8</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f9_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f9_hotkey" >
                         <div class="badge badge-dark">F9</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f10_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f10_hotkey" >
                         <div class="badge badge-dark">F10</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f11_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f11_hotkey" >
                         <div class="badge badge-dark">F11</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
-                      <li class="list-group-item text-nowrap p-1" id="f12_hotkey" >
+                      <li class="list-group-item text-nowrap unselectable" id="f12_hotkey" >
                         <div class="badge badge-dark">F12</div>
-                        <span></span>
+                        <span draggable='true' ondragstart='songDrag(event)'></span>
                       </li>
                     </ul>
                     

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -67,19 +67,24 @@ font-size: 11px;
 }
 
 .hotkeys li {
-  margin-bottom: 3px;
+  padding: 4px 0 7px 0;
   overflow: hidden;
+  cursor: pointer;
 }
 
 .hotkeys .badge {
   width: 30px;
-  margin-right: 2px;
-  background-color: slategray;
+  margin-right: 0;
+  background-color: darkslategray;
 }
 
 .hotkeys span {
   font-size: 12px;
   font-weight: bold;
+  padding: 5px;
+  padding-left: 3px;
+  border-radius: 5px;
+  overflow: hidden;
 }
 
 .dragenter {


### PR DESCRIPTION
Adds a number of features to the Hotkeys panel:

- Hotkeys can be clicked on to select. A selected Hotkey can be played (with the play button or pressing return), deleted, or dragged into the Holding Tank. Or sent to the Holding Tank with Shift-Tab.

- Hotkeys can be re-ordered by dragging. A Hotkey dragged into an empty slot will move to that slot. A hotkey dragged to an occupied slot will swap places with the song in that slot.