### PR TITLE
Configuration for Mac code signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To build packages for release, use the `npm run make` command. This will use the
 
 Build output of `npm run make` will be available in the `out/` subdirectory. Currently, this produces both a `.dmg` and a `.zip` file, with the `.dmg` being preferred.
 
+To enable debug output of the make command, set this environment variable: `DEBUG=electron-osx-sign*`
+
 ### Windows
 
 It is allegedly possible to build Windows binaries on the Mac, though getting that to work has proven challenging.

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,0 +1,65 @@
+const path = require('path')
+const fs = require('fs')
+const packageJson = require('./package.json')
+
+const { version } = packageJson
+const iconDir = path.resolve(__dirname, 'src', 'assets', 'icons')
+
+const config = {
+  packagerConfig: {
+    icon: "src/assets/icons/mxvoice",
+    osxSign: {
+      hardenedRuntime: true,
+      platform: "darwin",
+      'gatekeeper-assess': false,
+      entitlements: "static/entitlements.plist",
+      'entitlements-inherit': "static/entitlements.plist",
+      'signature-flags': "library"
+    },
+    osxNotarize: {
+      appleId: process.env.APPLE_ID,
+      appleIdPassword: process.env.APPLE_ID_PASSWORD
+    }
+  },
+  makers: [
+    {
+      name: "@electron-forge/maker-squirrel",
+      config: {
+        setupIcon: "src/assets/icons/mxvoice.ico"
+      }
+    },
+    {
+      name: "@electron-forge/maker-dmg",
+      platforms: [
+        'darwin'
+      ],
+      config: {
+        background: "src/assets/images/dmg-background-image.png",
+        icon: "src/assets/icons/dmg-image.icns",
+        additionalDMGOptions: {
+
+        }
+      }
+    },
+    {
+      name: "@electron-forge/maker-zip",
+      platforms: [
+        "darwin"
+      ]
+    }
+  ],
+  publishers: [
+    {
+      name: "@electron-forge/publisher-github",
+      config: {
+        repository: {
+          owner: "minter",
+          name: "mxvoice-electron"
+        },
+        prerelease: true
+      }
+    }
+  ]
+}
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "productName": "Mx. Voice",
   "version": "3.0.0-beta1",
   "description": "Improv Audio Software",
+  "appBundleId": "app.mxvoice.mxvoice",
   "main": "src/index.js",
   "scripts": {
     "start": "electron-forge start",
@@ -18,47 +19,7 @@
   },
   "license": "MIT",
   "config": {
-    "forge": {
-      "packagerConfig": {
-        "icon": "src/assets/icons/mxvoice"
-      },
-      "makers": [
-        {
-          "name": "@electron-forge/maker-squirrel",
-          "config": {
-            "setupIcon": "src/assets/icons/mxvoice.ico"
-          }
-        },
-        {
-          "name": "@electron-forge/maker-dmg",
-          "platforms": [
-            "darwin"
-          ],
-          "config": {
-            "background": "src/assets/images/dmg-background-image.png",
-            "icon": "src/assets/icons/dmg-image.icns"
-          }
-        },
-        {
-          "name": "@electron-forge/maker-zip",
-          "platforms": [
-            "darwin"
-          ]
-        }
-      ],
-      "publishers": [
-        {
-          "name": "@electron-forge/publisher-github",
-          "config": {
-            "repository": {
-              "owner": "minter",
-              "name": "mxvoice-electron"
-            },
-            "prerelease": true
-          }
-        }
-      ]
-    }
+    "forge": "./forge.config.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",

--- a/static/entitlements.plist
+++ b/static/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
To build a package for release, requires APPLE_ID and APPLE_ID_PASSWORD with the ability to sign code.

Moves Forge config into its own file for simplicity. Based on https://github.com/electron/fiddle/blob/master/forge.config.js