### PR TITLE
Allow top panels to be re-order via drag-and-drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mxvoice",
-  "version": "3.0.0-beta2",
+  "version": "3.0.0-beta4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.html
+++ b/src/index.html
@@ -36,9 +36,9 @@
 
         <!-- Begin Holding Tank -->
 
-        <div class="col-3 top-column" id="holding-tank-column" draggable='true' ondragstart='columnDrag(event)'>
+        <div class="col col-3" id="holding-tank-column" draggable='true' ondragstart='columnDrag(event)'>
 
-          <div class="h-100 card rounded-0" style="margin-right: -12px;">
+          <div class="h-100 card rounded-0">
             <h6 class="card-header rounded-0 bg-dark">
               <span id="holding_tank_label">Holding Tank</span> &nbsp;<a href="#">
 
@@ -90,7 +90,7 @@
 
         <!-- Begin Search -->
 
-        <div class="col-6 top-column" id="search-column" draggable='true' ondragstart='columnDrag(event)'>
+        <div class="col col-6" id="search-column" draggable='true' ondragstart='columnDrag(event)'>
 
           <div class="card rounded-0 h-100">
             <h6 class="card-header rounded-0 bg-dark">Search
@@ -140,9 +140,9 @@
 
         <!-- Begin Hotkeys -->
 
-        <div class="col-3 top-column" id="hotkeys-column" draggable='true' ondragstart='columnDrag(event)'>
+        <div class="col col-3" id="hotkeys-column" draggable='true' ondragstart='columnDrag(event)'>
 
-          <div class="card h-100 rounded-0"style="margin-left: -12px;">
+          <div class="card h-100 rounded-0">
                 <h6 class="card-header rounded-0 bg-dark">
                   Hotkeys
                     <div class="icon-bar">

--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
 
         <!-- Begin Holding Tank -->
 
-        <div class="col-3" id="holding-tank-colum">
+        <div class="col-3 top-column" id="holding-tank-column" draggable='true' ondragstart='columnDrag(event)'>
 
           <div class="h-100 card rounded-0" style="margin-right: -12px;">
             <h6 class="card-header rounded-0 bg-dark">
@@ -90,7 +90,7 @@
 
         <!-- Begin Search -->
 
-        <div class="col-6" id="search-column">
+        <div class="col-6 top-column" id="search-column" draggable='true' ondragstart='columnDrag(event)'>
 
           <div class="card rounded-0 h-100">
             <h6 class="card-header rounded-0 bg-dark">Search
@@ -140,7 +140,7 @@
 
         <!-- Begin Hotkeys -->
 
-        <div class="col-3" id="hotkeys-column">
+        <div class="col-3 top-column" id="hotkeys-column" draggable='true' ondragstart='columnDrag(event)'>
 
           <div class="card h-100 rounded-0"style="margin-left: -12px;">
                 <h6 class="card-header rounded-0 bg-dark">
@@ -272,7 +272,7 @@
               <div id="controls_column" class="col-3 d-flex align-items-center">
                 <button id="loop_button" class="btn btn-secondary btn-sm"><i title="Loop" class="fas fa-md fa-sync-alt fa-flip-vertical"></i></button>
                 <button id="mute_button" class="btn btn-secondary btn-sm"><i title="Mute" class="fas fa-md fa-volume-mute"></i></button>
-                <input type="range" class="custom-range mousetrap" value="100" id="volume">                
+                <input type="range" class="custom-range mousetrap" value="100" id="volume">
               </div>
             </div>
           </div>
@@ -336,15 +336,23 @@
           <div class="modal-body">
             <form onsubmit="saveBulkUpload(event)">
               <div class="form-group row">
-                <label for="bulk-add-category" class="col-sm-2 col-form-label">Category</label>
-                <div class="col-sm-10">
+                <label for="bulk-add-category" class="col-sm-3 col-form-label">Category</label>
+                <div class="col-sm-9">
                   <select class="form-control form-control-sm" id="bulk-add-category">
                   </select>
                 </div>
               </div>
+
+              <div id="bulkSongFormNewCategory" style="display: none" class="form-group row">
+                <label for="bulk-song-form-new-category" class="col-form-label col-sm-3 text-nowrap">Category Name</label>
+                <div class="col-sm-9">
+                  <input type="text" class="form-control form-control-sm" id="bulk-song-form-new-category" required>
+                </div>
+              </div>
+
               <div class="form-group row">
-                <label for="bulk-add-path" class="col-form-label col-sm-2">Source Directory</label>
-                <div class="col-sm-10">
+                <label for="bulk-add-path" class="col-form-label col-sm-3">Source Directory</label>
+                <div class="col-sm-9">
                   <input type="text" class="form-control form-control-sm" id="bulk-add-path" disabled>
                 </div>
               </div>
@@ -372,34 +380,41 @@
                 <input type="hidden" id="song-form-filename">
                 <input type="hidden" id="song-form-songid">
               <div class="form-group row">
-                <label for="song-form-category" class="col-sm-2 col-form-label">Category</label>
-                <div class="col-sm-10">
-                  <select class="form-control form-control-sm" id="song-form-category" required>
+                <label for="song-form-category" class="col-sm-3 col-form-label">Category</label>
+                <div class="col-sm-9">
+                  <select class="form-control form-control-sm category-menu" id="song-form-category" required>
                   </select>
                 </div>
-
               </div>
+
+              <div id="SongFormNewCategory" style="display: none" class="form-group row">
+                <label for="song-form-new-category" class="col-form-label col-sm-3 text-nowrap">Category Name</label>
+                <div class="col-sm-9">
+                  <input type="text" class="form-control form-control-sm" id="song-form-new-category" required>
+                </div>
+              </div>
+
               <div class="form-group row">
-                <label for="song-form-title" class="col-form-label col-sm-2">Title</label>
-                <div class="col-sm-10">
+                <label for="song-form-title" class="col-form-label col-sm-3">Title</label>
+                <div class="col-sm-9">
                   <input type="text" class="form-control form-control-sm" id="song-form-title" required>
                 </div>
               </div>
               <div class="form-group row">
-                <label for="song-form-artist" class="col-form-label col-sm-2">Artist</label>
-                <div class="col-sm-10">
+                <label for="song-form-artist" class="col-form-label col-sm-3">Artist</label>
+                <div class="col-sm-9">
                   <input type="text" class="form-control form-control-sm" id="song-form-artist">
                 </div>
               </div>
               <div class="form-group row">
-                <label for="song-form-info" class="col-form-label col-sm-2">Info</label>
-                <div class="col-sm-10">
+                <label for="song-form-info" class="col-form-label col-sm-3">Info</label>
+                <div class="col-sm-9">
                   <input type="text" class="form-control form-control-sm" id="song-form-info">
                 </div>
               </div>
               <div class="form-group row">
                 <label for="song-form-duration" class="col-form-label col-sm-2">Duration</label>
-                <div class="col-sm-10">
+                <div class="col-sm-9">
                   <input type="test" class="form-control form-control-sm" id="song-form-duration" disabled="disabled">
                 </div>
               </div>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -373,6 +373,16 @@ function songDrag(event) {
   event.dataTransfer.setData("text", event.target.getAttribute('songid'));
 }
 
+function columnDrag(event) {
+  console.log("Starting drag for column ID " + event.target.getAttribute("id"));
+  event.dataTransfer.setData(
+    "application/x-moz-node",
+    event.target.getAttribute("id")
+  );
+  console.log(event.dataTransfer.getData(
+    "application/x-moz-node"));
+}
+
 function sendToHotkeys() {
   if ($("#selected_row").is("span")) {
     return;
@@ -864,6 +874,7 @@ $( document ).ready(function() {
 
   $(".hotkeys li").on("drop", function (event) {
     $(this).removeClass("drop_target");
+    if (!event.originalEvent.dataTransfer.getData("text").length) return;
     hotkeyDrop(event.originalEvent);
   });
 
@@ -882,8 +893,28 @@ $( document ).ready(function() {
   });
 
   $("#holding_tank").on("drop", function (event) {
-    holdingTankDrop(event.originalEvent);
     $(event.originalEvent.target).removeClass("dropzone");
+    if (!event.originalEvent.dataTransfer.getData("text").length) return;
+    holdingTankDrop(event.originalEvent);
+  });
+
+  $(".card-header").on("dragover", function (event) {
+    event.preventDefault();
+  });
+
+  $(".card-header").on("drop", function (event) {
+    if (event.originalEvent.dataTransfer.getData("text").length) return;
+    var original_column = $(
+      `#${event.originalEvent.dataTransfer.getData("application/x-moz-node")}`
+    );
+    var target_column = $(event.target).parent().parent();
+    var parent_div = [...target_column.parent().children()];
+    if (parent_div.indexOf(original_column) > parent_div.indexOf(target_column)) {
+      target_column.after(original_column.detach());
+    } else {
+      target_column.before(original_column.detach());
+    }
+
   });
 
   $("#holding_tank").on("dragover", function (event) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -375,12 +375,7 @@ function songDrag(event) {
 
 function columnDrag(event) {
   console.log("Starting drag for column ID " + event.target.getAttribute("id"));
-  event.dataTransfer.setData(
-    "application/x-moz-node",
-    event.target.getAttribute("id")
-  );
-  console.log(event.dataTransfer.getData(
-    "application/x-moz-node"));
+  event.dataTransfer.setData("application/x-moz-node",event.target.getAttribute("id"));
 }
 
 function sendToHotkeys() {
@@ -904,17 +899,14 @@ $( document ).ready(function() {
 
   $(".card-header").on("drop", function (event) {
     if (event.originalEvent.dataTransfer.getData("text").length) return;
-    var original_column = $(
-      `#${event.originalEvent.dataTransfer.getData("application/x-moz-node")}`
-    );
-    var target_column = $(event.target).parent().parent();
-    var parent_div = [...target_column.parent().children()];
-    if (parent_div.indexOf(original_column) > parent_div.indexOf(target_column)) {
-      target_column.after(original_column.detach());
-    } else {
+    var original_column = $(`#${event.originalEvent.dataTransfer.getData("application/x-moz-node")}`);
+    var target_column = $(event.target).closest('.col');
+    var columns = $('#top-row').children();
+    if (columns.index(original_column) > columns.index(target_column)) {
       target_column.before(original_column.detach());
+    } else {
+      target_column.after(original_column.detach());
     }
-
   });
 
   $("#holding_tank").on("dragover", function (event) {

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -16,11 +16,6 @@ body {
   border: 1px solid #666;
 }
 
-.card-body {
-  position: relative;
-  left: -5px;
-}
-
 .card-header {
   background-color: #0d324d;
 }
@@ -253,7 +248,7 @@ h6 a {
 }
 
 #holding-tank-column, #hotkeys-column {
-  min-width: 250px;
+  min-width: 300px;
 }
 
 #search-column {


### PR DESCRIPTION
Lets the user re-order the Holding Tank, Search and Hotkeys panels via drag-and-drop (as requested by Ken Wells). Panel must be dragged reasonably horizontally (i.e. header to header). Dragging panel into body of another panel should have no effect.

Point for discussion: should display order be automatically stored so the next time the app is opened it returns to the last order? My instinct is no if most theaters have multiple users. Could also make a preference called "Remember panel order" to have that be user configurable.