### PR TITLE
Fix how autoplay works

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
 
         <!-- Begin Holding Tank -->
 
-        <div class="col-3" id="holding-tank-colum">
+        <div class="col-3" id="holding-tank-column">
 
           <div class="h-100 card rounded-0" style="margin-right: -12px;">
             <h6 class="card-header rounded-0 bg-dark">

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,6 +11,8 @@ function playSongFromHotkey(hotkey) {
   console.log (`Found song ID ${song_id}`);
   if (song_id) {
     console.log (`Preparing to play song ${song_id}`);
+    autoplay = true;
+    toggleAutoPlay();
     playSongFromId(song_id);
      $(`.hotkeys.active #${hotkey}_hotkey`).fadeOut(100).fadeIn(100);
   }
@@ -286,8 +288,6 @@ function autoplay_next() {
       now_playing.removeClass("now_playing");
       next_song = now_playing.next();
       next_song.addClass("now_playing");
-    } else {
-      next_song = $(".holding_tank.active li").first();
     }
     if (next_song.length) {
       playSongFromId(next_song.attr("songid"));
@@ -298,9 +298,17 @@ function autoplay_next() {
   }
 }
 
+function cancel_autoplay() {
+  if (!$("#holding-tank-column").has($("#selected_row")).length) {
+    autoplay = true;
+    toggleAutoPlay();
+  }
+}
+
 function playSelected(){
   var song_id = $('#selected_row').attr('songid');
   console.log('Got song ID ' + song_id);
+  cancel_autoplay();
   playSongFromId(song_id);
 }
 
@@ -408,14 +416,15 @@ function selectPrev() {
 
 function toggleAutoPlay() {
     autoplay = !autoplay;
-    $("#autoplay_button").toggleClass("fa-stop fa-play-circle");
-    $("#holding_tank").toggleClass("autoplaying");
     $(".now_playing").removeClass("now_playing");
+    $("#autoplay_button").toggleClass("fa-stop fa-play-circle");
     if (autoplay) {
       $("#holding_tank_label").html("Auto Play");
       $(`.holding_tank li[songid=${$('#song_now_playing').attr('songid')}]`).addClass('now_playing');
+      $("#holding_tank").addClass("autoplaying");
     } else {
-      $("#holding_tank_label").html("Holding Tank");
+      $("#holding_tank_label").html("Holding Tank");      
+      $("#holding_tank").removeClass("autoplaying");
     }
 
 }


### PR DESCRIPTION
Fixes a couple issues with Autoplay reported by Pat Short:

- When a song is playing via Autoplay, playing a song outside Autoplay (either via double-clicking on search results or via a hotkey) disables Autoplay. 

- When Autoplay reaches the end of the list it stops vs looping back to the beginning.