### PR TITLE
Fix console errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,7 @@ typings/
 
 # Electron-Forge
 out/
+
+# VS Code Debug Configuration
+
+.vscode/

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -231,23 +231,22 @@ var howlerUtils = {
     return (s.state() == 'loaded');
   },
 	updateTimeTracker: function () {
-    if (howlerUtils.isLoaded(sound)) {
-      var self = this;
-      var seek = sound.seek() || 0;
-      var remaining = self.duration() - seek;
-      var currentTime = howlerUtils.formatTime(Math.round(seek));
-      var remainingTime = howlerUtils.formatTime(Math.round(remaining));
-      var percent_elapsed = seek / self.duration();
-      $("#audio_progress").width((percent_elapsed * 100 || 0) + "%");
-      if (!isNaN(percent_elapsed)) wavesurfer.seekTo(percent_elapsed);
-      $("#timer").text(currentTime);
-      $("#duration").text(`-${remainingTime}`);
-      globalAnimation = requestAnimationFrame(howlerUtils.updateTimeTracker.bind(self));
-    } else {
+    if (!howlerUtils.isLoaded(sound)) {
       cancelAnimationFrame(globalAnimation);
       wavesurfer.empty();
+      return;
     }
-		
+    var self = this;
+    var seek = sound.seek() || 0;
+    var remaining = self.duration() - seek;
+    var currentTime = howlerUtils.formatTime(Math.round(seek));
+    var remainingTime = howlerUtils.formatTime(Math.round(remaining));
+    var percent_elapsed = seek / self.duration();
+    $("#audio_progress").width((percent_elapsed * 100 || 0) + "%");
+    if (!isNaN(percent_elapsed)) wavesurfer.seekTo(percent_elapsed);
+    $("#timer").text(currentTime);
+    $("#duration").text(`-${remainingTime}`);
+    globalAnimation = requestAnimationFrame(howlerUtils.updateTimeTracker.bind(self));
 	}
 };
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -226,9 +226,12 @@ var howlerUtils = {
 		var minutes = Math.floor(secs / 60) || 0;
 		var seconds = (secs - minutes * 60) || 0;
 		return minutes + ':' + (seconds < 10 ? '0' : '') + seconds;
-	},
+  },
+  isLoaded: function(s) {
+    return (s.state() == 'loaded');
+  },
 	updateTimeTracker: function () {
-    if (sound.state()=="loaded") {
+    if (howlerUtils.isLoaded(sound)) {
       var self = this;
       var seek = sound.seek() || 0;
       var remaining = self.duration() - seek;

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -236,6 +236,7 @@ h6 a {
   z-index: 1;
   border-radius: 10px 10px 0 0;
   opacity: .95;
+  cursor: pointer;
 }
 
 .hidden {


### PR DESCRIPTION
Couple changes here to make playback a bit more reliable and to prevent console errors from wavesurfer or Howler.

- Changes `sound.stop()` to `sound.unload()`, which prevents Howler from trying to start a new sound on top of an old sound or otherwise getting confused.

- Reworks the `howlerUtils.updateTimeTracker` function to only fire if a sound is loaded; otherwise, it calls cancelAnimationFrame which prevents from being called again.

- Removes the `is_playing` boolean. This was a hack to stop `updateTimeTracker` from firing after a song had been stopped (because things can happen asynchronously). No longer needed now that `updateTimeTracker` will never fire if a sound isn't loaded.

- Discovered that `sound.seek()` sometimes returns the object itself instead of a numerical value if called in the middle of executing a seek. This might be a bug in Howler itself, but we now trap for this so we never attempt to call wavesurfer with an invalid value.

- Updated `.gitignore` with VS Code specific debugging stuff.
