### PR TITLE
Use custom stylesheet for dark mode on prompts

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -541,6 +541,7 @@ function renameHotkeyTab() {
     value: $("#hotkey_tabs .nav-link.active").text(),
     type: "input",
     alwaysOnTop: true,
+    customStylesheet: 'src/stylesheets/colors.css'
   })
     .then((r) => {
       if (r === null) {
@@ -634,6 +635,7 @@ function renameHoldingTankTab() {
     value: $("#holding_tank_tabs .nav-link.active").text(),
     type: "input",
     alwaysOnTop: true,
+    customStylesheet: 'src/stylesheets/colors.css'
   })
     .then((r) => {
       if (r === null) {

--- a/src/stylesheets/colors.css
+++ b/src/stylesheets/colors.css
@@ -149,3 +149,79 @@ table td {
   background-color: var(--card-text);
   color: var(--inverse-card-text);
 }
+
+/* Styling for prompt boxes */
+
+body {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    line-height: 1.5em;
+    color: var(--card-text);
+    background-color: var(--panel-color);
+}
+
+#container {
+    align-items: center;
+    justify-content: center;
+    display: flex;
+    height: 100%;
+    overflow: auto;
+
+}
+
+#form {
+    width: 100%;
+}
+
+#label {
+    max-width: 100%;
+    max-height: 100%;
+    margin-bottom: .8em;
+    padding: 0 .5em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#data {
+    border-radius: 2px;
+    background: var(--panel-color);
+    color: var(--card-text);
+    width: 90%;
+    padding: .4em .5em;
+    border: 1px solid black;
+    min-height: 2em;
+    margin: 0 0 1.2em;
+}
+
+select#data {
+    height: 2em;
+}
+
+#data-container {
+    text-align: center;
+}
+
+#buttons {
+    text-align: right;
+    padding: 0 .5em 0 0;
+}
+
+#buttons > button,
+#buttons > input[type=submit] {
+    border-radius: 2px;
+    border: 0;
+    margin: 0 0 0 .5em;
+    font-size: .8em;
+    line-height: 1em;
+    padding: .6em 1em
+}
+
+#ok {
+    background-color: #3879D9;
+    color: var(--inverse-card-text);
+}
+
+#cancel {
+    background-color: var(--card-border);
+    color: var(--inverse-card-text);
+}


### PR DESCRIPTION
The popup prompts to rename hotkeys/holding tank tabs wasn't respecting dark mode, which was bugging me. This adds the CSS for the prompt boxes to `colors.css`, and uses variables to set colors that respect dark mode.

### Dark Mode:

![Screen Shot 2020-07-19 at 1 34 41 PM](https://user-images.githubusercontent.com/955/87881059-b1ae8900-c9c4-11ea-9aff-273ad4bffff2.png)

### Light Mode:

![Screen Shot 2020-07-19 at 1 34 54 PM](https://user-images.githubusercontent.com/955/87881061-b6733d00-c9c4-11ea-88ff-e1a8e766b315.png)

## Previous Behavior

![Screen Shot 2020-07-19 at 1 36 04 PM](https://user-images.githubusercontent.com/955/87881068-d440a200-c9c4-11ea-914a-a9367656fc29.png)
