### PR TITLE
Remove remote module, fix dialog boxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mxvoice",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mxvoice",
   "productName": "Mx. Voice",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Improv Audio Software",
   "repository": "https://github.com/minter/mxvoice-electron",
   "appBundleId": "app.mxvoice.mxvoice",

--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,19 @@ if (process.platform == 'darwin') {
   })
 }
 
+ipcMain.handle('get-app-path', async (event) => {
+  const result = await app.getAppPath();
+  return result
+})
+
+ipcMain.handle('show-directory-picker', async (event, defaultPath) => {
+  let path = dialog.showOpenDialogSync({
+    defaultPath: defaultPath,
+    properties: ['openDirectory']
+  });
+  return path
+})
+
 ipcMain.on('open-hotkey-file', (event, arg) => {
   console.log("Main process starting hotkey open");
   loadHotkeysFile();

--- a/src/preload.js
+++ b/src/preload.js
@@ -5,7 +5,6 @@ const store = new Store();
 const path = require('path')
 const fs = require('fs')
 const log = require('electron-log');
-const { dialog } = require('electron').remote
 console.log = log.log;
 var dbName = 'mxvoice.db'
 console.log(`Looking for database in ${store.get('database_directory')}`)
@@ -107,8 +106,7 @@ process.once('loaded', () => {
   global.mm = mm,
   global.util = require('util'),
   global.fs = fs,
-  global.db = db,
-  global.dialog = dialog
+  global.db = db
 
   if (db.pragma('index_info(category_code_index)').length == 0) {
     console.log(`Creating unique index on category codes`)

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -538,23 +538,25 @@ function switchToHotkeyTab(tab) {
 }
 
 function renameHotkeyTab() {
-
-  prompt({
-    title: "Rename Hotkey Tab",
-    label: "Rename this tab:",
-    value: $("#hotkey_tabs .nav-link.active").text(),
-    type: "input",
-    alwaysOnTop: true,
-    customStylesheet: 'src/stylesheets/colors.css'
-  })
-    .then((r) => {
-      if (r === null) {
-        console.log("user canceled");
-      } else {
-        $("#hotkey_tabs .nav-link.active").text(r);
-      }
+  ipcRenderer.invoke('get-app-path').then((result) => {
+    prompt({
+      title: "Rename Hotkey Tab",
+      label: "Rename this tab:",
+      value: $("#hotkey_tabs .nav-link.active").text(),
+      type: "input",
+      alwaysOnTop: true,
+      customStylesheet: path.join(result, 'src/stylesheets/colors.css')
     })
-    .catch(console.error);
+      .then((r) => {
+        if (r === null) {
+          console.log("user canceled");
+        } else {
+          $("#hotkey_tabs .nav-link.active").text(r);
+        }
+      })
+      .catch(console.error);
+
+  })
 }
 
 function saveEditedSong(event) {
@@ -644,22 +646,24 @@ function savePreferences(event) {
 
 
 function renameHoldingTankTab() {
-  prompt({
-    title: "Rename Holding Tank Tab",
-    label: "Rename this tab:",
-    value: $("#holding_tank_tabs .nav-link.active").text(),
-    type: "input",
-    alwaysOnTop: true,
-    customStylesheet: 'src/stylesheets/colors.css'
-  })
-    .then((r) => {
-      if (r === null) {
-        console.log("user canceled");
-      } else {
-        $("#holding_tank_tabs .nav-link.active").text(r);
-      }
+  ipcRenderer.invoke('get-app-path').then((result) => {
+    prompt({
+      title: "Rename Holding Tank Tab",
+      label: "Rename this tab:",
+      value: $("#holding_tank_tabs .nav-link.active").text(),
+      type: "input",
+      alwaysOnTop: true,
+      customStylesheet: path.join(result, 'src/stylesheets/colors.css')
     })
-    .catch(console.error);
+      .then((r) => {
+        if (r === null) {
+          console.log("user canceled");
+        } else {
+          $("#holding_tank_tabs .nav-link.active").text(r);
+        }
+      })
+      .catch(console.error);
+    });
 }
 
 function editSelectedSong() {
@@ -962,11 +966,10 @@ function loop_on(bool) {
 
 function pickDirectory(event, element) {
   event.preventDefault();
-  let path = dialog.showOpenDialogSync({
-    defaultPath: $(element).val(),
-    properties: ['openDirectory']
+  defaultPath = $(element).val();
+  ipcRenderer.invoke('show-directory-picker', defaultPath).then((result) => {
+    if (result) $(element).val(result);
   });
-  if (path) $(element).val(path);
 }
 
 function installUpdate() {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -51,8 +51,12 @@ function playSongFromHotkey(hotkey) {
 function populateHotkeys(fkeys, title) {
   for (var key in fkeys) {
     if (fkeys[key]) {
-      $(`.hotkeys.active #${key}_hotkey`).attr('songid', fkeys[key]);
-      setLabelFromSongId(fkeys[key], $(`.hotkeys.active #${key}_hotkey`))
+      try {
+        $(`.hotkeys.active #${key}_hotkey`).attr('songid', fkeys[key]);
+        setLabelFromSongId(fkeys[key], $(`.hotkeys.active #${key}_hotkey`))
+      } catch(err) {
+        console.log(`Error loading fkey ${key} (DB ID: ${fkeys[key]})`)
+      }
     }
     else {
       $(`.hotkeys.active #${key}_hotkey`).removeAttr('songid');


### PR DESCRIPTION
Something broke with Electron 9 in the electron-prompt boxes, so that it failed loading the custom stylesheets for coloring. This led to a refactor of using IPC to get the app path in the main process, then send it over to the renderer.

Also refactors away the remote module usage for the directory picker in preferences, since remote will go away at some point soon.