### PR TITLE
Save Application State

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ const store = new Store({
   defaults: defaults
 });
 
+// Uncomment this to view contents of store
+//store.openInEditor();
 
 const server = 'https://mxvoice.now.sh'
 const feed = `${server}/update/${process.platform}/${app.getVersion()}`
@@ -253,6 +255,13 @@ var application_menu = [
         accelerator: "CommandOrControl+M",
         click: () => {
           toggleAdvancedSearch();
+        },
+      },
+      { type: "separator" },
+      {
+        label: "Start a New Session",
+        click: () => {
+          closeAllTabs();
         },
       },
     ],
@@ -610,6 +619,10 @@ Menu.setApplicationMenu(menu);
     function toggleAdvancedSearch() {
       console.log("Toggling advanced search");
       mainWindow.webContents.send("toggle_advanced_search");
+    }
+
+    function closeAllTabs() {
+      mainWindow.webContents.send("close_all_tabs");
     }
 
     function sendDeleteSong() {

--- a/src/preload.js
+++ b/src/preload.js
@@ -103,6 +103,10 @@ ipcRenderer.on("toggle_advanced_search", function (event) {
   toggleAdvancedSearch();
 });
 
+ipcRenderer.on("close_all_tabs", function (event) {
+  closeAllTabs();
+});
+
 ipcRenderer.on('display_release_notes', function(event, releaseName, releaseNotes) {
   $('#newReleaseModal .modal-title').html(`Downloaded New Version: ${releaseName}`);
   $('#newReleaseModal .modal-body').html(releaseNotes);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -15,6 +15,16 @@ var wavesurfer = WaveSurfer.create({
 });
 var fontSize = 11;
 
+// Load the last holding tank and hotkeys
+
+if (store.has('holding_tank')) {
+  $("#holding-tank-column").html(store.get("holding_tank"));
+}
+
+if (store.has("hotkeys")) {
+  $("#hotkeys-column").html(store.get("hotkeys"));
+}
+
 // Animate.css
 
 const animateCSS = (element, animation, speed = '', prefix = 'animate__') =>
@@ -35,6 +45,14 @@ const animateCSS = (element, animation, speed = '', prefix = 'animate__') =>
 
     node.on('animationend', handleAnimationEnd);
   });
+
+function saveHoldingTankToStore() {
+  store.set('holding_tank', $('#holding-tank-column').html());
+}
+
+function saveHotkeysToStore() {
+  store.set("hotkeys", $("#hotkeys-column").html());
+}
 
 function playSongFromHotkey(hotkey) {
   console.log ('Getting song ID from hotkey ' + hotkey);
@@ -234,6 +252,7 @@ function setLabelFromSongId(song_id, element) {
     $(element).find("span").html(`${title} by ${artist} (${time})`);
     $(element).find("span").attr("songid", song_id);
   }
+  saveHotkeysToStore();
 }
 
 function addToHoldingTank(song_id, element) {
@@ -258,6 +277,7 @@ function addToHoldingTank(song_id, element) {
   } else {
     $(element).append(song_row);
   }
+  saveHoldingTankToStore();
 }
 
 var howlerUtils = {
@@ -526,6 +546,8 @@ function deleteSong() {
     } else {
       $("#selected_row").remove();
     }
+      saveHoldingTankToStore();
+      saveHotkeysToStore();
   });
   return false;
 }
@@ -732,6 +754,8 @@ function deleteSelectedSong() {
         $(`.hotkeys li span[songid=${songId}]`).remove();
         $(`.hotkeys li [songid=${songId}]`).removeAttr('id');
         $(`#search_results tr[songid=${songId}]`).remove();
+        saveHoldingTankToStore();
+        saveHotkeysToStore();
       } else {
         console.log("Error deleting song from database")
       }
@@ -1030,6 +1054,13 @@ function toggleAdvancedSearch() {
   }
 }
 
+function closeAllTabs() {
+  if (confirm(`Are you sure you want to close all open Holding Tanks and Hotkeys?`)) {
+    store.delete('holding_tank');
+    store.delete('hotkeys');
+    location.reload();
+  }
+}
 
 $( document ).ready(function() {
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -19,10 +19,16 @@ var fontSize = 11;
 
 if (store.has('holding_tank')) {
   $("#holding-tank-column").html(store.get("holding_tank"));
+  $("#selected_row").removeAttr("id");
+  $("#autoplay_button").replaceWith(
+    '<i title="AutoPlay" id="autoplay_button" onclick="toggleAutoPlay()" class="fas fa-md fa-play-circle"></i>');
+  autoplay = true;
+  toggleAutoPlay();
 }
 
 if (store.has("hotkeys")) {
   $("#hotkeys-column").html(store.get("hotkeys"));
+  $("#selected_row").removeAttr("id");
 }
 
 // Animate.css

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -64,7 +64,7 @@ font-size: 11px;
 }
 
 #now_playing_bar div {
-
+  font-weight: bold;
   font-size: 16px;
   padding-bottom: 8px;
   font-family: 'Share Tech Mono', 'Courier', sans-serif;


### PR DESCRIPTION
Saves the state of all open hotkeys and holding tanks and restores on relaunch. Also includes a menu item (View > Start a New Session) to clear out the saved state and start anew.

Works by saving the entire HTML of the holding tanks and hotkeys to electron store, and then restoring on relaunch. State is saved on any change to hotkeys or holding tank, i.e. song added/deleted/re-ordered, or loaded from hotkeys/holding tank loaded from disk.

Should not attempt to restore state if there is no saved state, i.e. if "Start a New Session" has reset the page and cleared the store items, or on first run.

Does not save state of search panel, currently playing songs or autoplay.


