### PR TITLE
Fix modal actions

### DIFF
--- a/src/renderer/modules/event-coordination/ui-interaction-events.js
+++ b/src/renderer/modules/event-coordination/ui-interaction-events.js
@@ -1,6 +1,6 @@
 /**
  * UI Interaction Events Module
- * 
+ *
  * Handles all UI interaction event handlers that were previously in renderer.js.
  * Includes modals, tabs, window resize, and form interactions.
  */
@@ -12,7 +12,7 @@ export default class UIInteractionEvents {
     this.store = null;
     this.debugLog = dependencies.debugLog || window.debugLog;
     this.moduleRegistry = dependencies.moduleRegistry || window.moduleRegistry;
-    
+
     this.eventsAttached = false;
     this.uiHandlers = new Map();
   }
@@ -23,11 +23,11 @@ export default class UIInteractionEvents {
   async attachUIInteractionEvents() {
     try {
       if (this.eventsAttached) {
-        this.debugLog?.warn('UI interaction events already attached');
+        this.debugLog?.warn("UI interaction events already attached");
         return;
       }
 
-      this.debugLog?.info('Attaching UI interaction event handlers...');
+      this.debugLog?.info("Attaching UI interaction event handlers...");
 
       // Modal events
       this.attachModalEvents();
@@ -45,10 +45,11 @@ export default class UIInteractionEvents {
       this.attachConfirmationEvents();
 
       this.eventsAttached = true;
-      this.debugLog?.info('UI interaction event handlers attached successfully');
-
+      this.debugLog?.info(
+        "UI interaction event handlers attached successfully"
+      );
     } catch (error) {
-      this.debugLog?.error('Failed to attach UI interaction events:', error);
+      this.debugLog?.error("Failed to attach UI interaction events:", error);
     }
   }
 
@@ -61,53 +62,54 @@ export default class UIInteractionEvents {
         // Hide other modals when one is shown
         $(".modal").modal("hide");
       } catch (error) {
-        this.debugLog?.error('Error in modal show handler:', error);
+        this.debugLog?.error("Error in modal show handler:", error);
       }
     };
 
     $(".modal").on("show.bs.modal", modalShowHandler);
-    this.uiHandlers.set('modalShow', { element: '.modal', event: 'show.bs.modal', handler: modalShowHandler });
-    
-    this.debugLog?.debug('Modal events attached');
+    this.uiHandlers.set("modalShow", {
+      element: ".modal",
+      event: "show.bs.modal",
+      handler: modalShowHandler,
+    });
+
+    this.debugLog?.debug("Modal events attached");
   }
 
   /**
    * Tab interaction events (lines 1114-1120 from renderer.js)
    */
   attachTabEvents() {
-    // Hotkey tab double-click for renaming
-    const hotkeyTabDoubleClickHandler = (event) => {
-      try {
-        if (window.renameHotkeyTab) {
-          window.renameHotkeyTab();
-        } else {
-          this.debugLog?.warn('renameHotkeyTab function not available');
-        }
-      } catch (error) {
-        this.debugLog?.error('Error in hotkey tab double-click handler:', error);
-      }
-    };
-
     // Holding tank tab double-click for renaming
     const holdingTankTabDoubleClickHandler = (event) => {
       try {
         if (window.renameHoldingTankTab) {
           window.renameHoldingTankTab();
         } else {
-          this.debugLog?.warn('renameHoldingTankTab function not available');
+          this.debugLog?.warn("renameHoldingTankTab function not available");
         }
       } catch (error) {
-        this.debugLog?.error('Error in holding tank tab double-click handler:', error);
+        this.debugLog?.error(
+          "Error in holding tank tab double-click handler:",
+          error
+        );
       }
     };
 
-    $("#hotkey_tabs").on("dblclick", ".nav-link", hotkeyTabDoubleClickHandler);
-    $("#holding_tank_tabs").on("dblclick", ".nav-link", holdingTankTabDoubleClickHandler);
+    $("#holding_tank_tabs").on(
+      "dblclick",
+      ".nav-link",
+      holdingTankTabDoubleClickHandler
+    );
 
-    this.uiHandlers.set('hotkeyTabDoubleClick', { element: '#hotkey_tabs', event: 'dblclick', selector: '.nav-link', handler: hotkeyTabDoubleClickHandler });
-    this.uiHandlers.set('holdingTankTabDoubleClick', { element: '#holding_tank_tabs', event: 'dblclick', selector: '.nav-link', handler: holdingTankTabDoubleClickHandler });
-    
-    this.debugLog?.debug('Tab events attached');
+    this.uiHandlers.set("holdingTankTabDoubleClick", {
+      element: "#holding_tank_tabs",
+      event: "dblclick",
+      selector: ".nav-link",
+      handler: holdingTankTabDoubleClickHandler,
+    });
+
+    this.debugLog?.debug("Tab events attached");
   }
 
   /**
@@ -119,17 +121,21 @@ export default class UIInteractionEvents {
         if (window.scaleScrollable) {
           window.scaleScrollable();
         } else {
-          this.debugLog?.warn('scaleScrollable function not available');
+          this.debugLog?.warn("scaleScrollable function not available");
         }
       } catch (error) {
-        this.debugLog?.error('Error in window resize handler:', error);
+        this.debugLog?.error("Error in window resize handler:", error);
       }
     };
 
     $(window).on("resize", windowResizeHandler);
-    this.uiHandlers.set('windowResize', { element: window, event: 'resize', handler: windowResizeHandler });
-    
-    this.debugLog?.debug('Window events attached');
+    this.uiHandlers.set("windowResize", {
+      element: window,
+      event: "resize",
+      handler: windowResizeHandler,
+    });
+
+    this.debugLog?.debug("Window events attached");
   }
 
   /**
@@ -147,21 +153,24 @@ export default class UIInteractionEvents {
         $("#song-form-duration").val("");
         $("#SongFormNewCategory").hide();
       } catch (error) {
-        this.debugLog?.error('Error in song form modal hidden handler:', error);
+        this.debugLog?.error("Error in song form modal hidden handler:", error);
       }
     };
 
     // Song form modal shown event
     const songFormModalShownHandler = (event) => {
       try {
-        this.debugLog?.debug('Song form title length:', $("#song-form-title").val().length);
+        this.debugLog?.debug(
+          "Song form title length:",
+          $("#song-form-title").val().length
+        );
         if (!$("#song-form-title").val().length) {
           $("#song-form-title").focus();
         } else {
           $("#song-form-info").focus();
         }
       } catch (error) {
-        this.debugLog?.error('Error in song form modal shown handler:', error);
+        this.debugLog?.error("Error in song form modal shown handler:", error);
       }
     };
 
@@ -174,18 +183,31 @@ export default class UIInteractionEvents {
           this.electronAPI.store.get("music_directory"),
           this.electronAPI.store.get("hotkey_directory"),
           this.electronAPI.store.get("fade_out_seconds"),
-          this.electronAPI.store.get("debug_log_enabled")
-        ]).then(([dbDir, musicDir, hotkeyDir, fadeSeconds, debugLog]) => {
-          if (dbDir.success) $("#preferences-database-directory").val(dbDir.value);
-          if (musicDir.success) $("#preferences-song-directory").val(musicDir.value);
-          if (hotkeyDir.success) $("#preferences-hotkey-directory").val(hotkeyDir.value);
-          if (fadeSeconds.success) $("#preferences-fadeout-seconds").val(fadeSeconds.value);
-          if (debugLog.success) $("#preferences-debug-log-enabled").prop("checked", debugLog.value);
-        }).catch(error => {
-          this.debugLog?.warn('Failed to load preferences', error);
-        });
+          this.electronAPI.store.get("debug_log_enabled"),
+        ])
+          .then(([dbDir, musicDir, hotkeyDir, fadeSeconds, debugLog]) => {
+            if (dbDir.success)
+              $("#preferences-database-directory").val(dbDir.value);
+            if (musicDir.success)
+              $("#preferences-song-directory").val(musicDir.value);
+            if (hotkeyDir.success)
+              $("#preferences-hotkey-directory").val(hotkeyDir.value);
+            if (fadeSeconds.success)
+              $("#preferences-fadeout-seconds").val(fadeSeconds.value);
+            if (debugLog.success)
+              $("#preferences-debug-log-enabled").prop(
+                "checked",
+                debugLog.value
+              );
+          })
+          .catch((error) => {
+            this.debugLog?.warn("Failed to load preferences", error);
+          });
       } catch (error) {
-        this.debugLog?.error('Error in preferences modal shown handler:', error);
+        this.debugLog?.error(
+          "Error in preferences modal shown handler:",
+          error
+        );
       }
     };
 
@@ -204,7 +226,10 @@ export default class UIInteractionEvents {
           }
         });
       } catch (error) {
-        this.debugLog?.error('Error in song form category change handler:', error);
+        this.debugLog?.error(
+          "Error in song form category change handler:",
+          error
+        );
       }
     };
 
@@ -213,15 +238,31 @@ export default class UIInteractionEvents {
     $("#preferencesModal").on("shown.bs.modal", preferencesModalShownHandler);
     $("#song-form-category").change(songFormCategoryChangeHandler);
 
-    this.uiHandlers.set('songFormModalHidden', { element: '#songFormModal', event: 'hidden.bs.modal', handler: songFormModalHiddenHandler });
-    this.uiHandlers.set('songFormModalShown', { element: '#songFormModal', event: 'shown.bs.modal', handler: songFormModalShownHandler });
-    this.uiHandlers.set('preferencesModalShown', { element: '#preferencesModal', event: 'shown.bs.modal', handler: preferencesModalShownHandler });
-    this.uiHandlers.set('songFormCategoryChange', { element: '#song-form-category', event: 'change', handler: songFormCategoryChangeHandler });
-    
+    this.uiHandlers.set("songFormModalHidden", {
+      element: "#songFormModal",
+      event: "hidden.bs.modal",
+      handler: songFormModalHiddenHandler,
+    });
+    this.uiHandlers.set("songFormModalShown", {
+      element: "#songFormModal",
+      event: "shown.bs.modal",
+      handler: songFormModalShownHandler,
+    });
+    this.uiHandlers.set("preferencesModalShown", {
+      element: "#preferencesModal",
+      event: "shown.bs.modal",
+      handler: preferencesModalShownHandler,
+    });
+    this.uiHandlers.set("songFormCategoryChange", {
+      element: "#song-form-category",
+      event: "change",
+      handler: songFormCategoryChangeHandler,
+    });
+
     // Trigger change event on page load
     $("#song-form-category").change();
-    
-    this.debugLog?.debug('Form events attached');
+
+    this.debugLog?.debug("Form events attached");
   }
 
   /**
@@ -233,17 +274,27 @@ export default class UIInteractionEvents {
         if (window.restoreFocusToSearch) {
           window.restoreFocusToSearch();
         } else {
-          this.debugLog?.warn('restoreFocusToSearch function not available');
+          this.debugLog?.warn("restoreFocusToSearch function not available");
         }
       } catch (error) {
-        this.debugLog?.error('Error in confirmation modal hidden handler:', error);
+        this.debugLog?.error(
+          "Error in confirmation modal hidden handler:",
+          error
+        );
       }
     };
 
-    $("#confirmationModal").on("hidden.bs.modal", confirmationModalHiddenHandler);
-    this.uiHandlers.set('confirmationModalHidden', { element: '#confirmationModal', event: 'hidden.bs.modal', handler: confirmationModalHiddenHandler });
-    
-    this.debugLog?.debug('Confirmation events attached');
+    $("#confirmationModal").on(
+      "hidden.bs.modal",
+      confirmationModalHiddenHandler
+    );
+    this.uiHandlers.set("confirmationModalHidden", {
+      element: "#confirmationModal",
+      event: "hidden.bs.modal",
+      handler: confirmationModalHiddenHandler,
+    });
+
+    this.debugLog?.debug("Confirmation events attached");
   }
 
   /**
@@ -251,12 +302,16 @@ export default class UIInteractionEvents {
    */
   detachEvents() {
     try {
-      this.debugLog?.info('Detaching UI interaction events...');
+      this.debugLog?.info("Detaching UI interaction events...");
 
       for (const [name, handler] of this.uiHandlers) {
         if (handler.selector) {
           // Delegated event
-          $(handler.element).off(handler.event, handler.selector, handler.handler);
+          $(handler.element).off(
+            handler.event,
+            handler.selector,
+            handler.handler
+          );
         } else {
           // Direct event
           $(handler.element).off(handler.event, handler.handler);
@@ -266,11 +321,10 @@ export default class UIInteractionEvents {
 
       this.uiHandlers.clear();
       this.eventsAttached = false;
-      
-      this.debugLog?.info('UI interaction events detached successfully');
 
+      this.debugLog?.info("UI interaction events detached successfully");
     } catch (error) {
-      this.debugLog?.error('Failed to detach UI interaction events:', error);
+      this.debugLog?.error("Failed to detach UI interaction events:", error);
     }
   }
 
@@ -281,7 +335,7 @@ export default class UIInteractionEvents {
     return {
       eventsAttached: this.eventsAttached,
       handlerCount: this.uiHandlers.size,
-      handlers: Array.from(this.uiHandlers.keys())
+      handlers: Array.from(this.uiHandlers.keys()),
     };
   }
 }

--- a/src/renderer/modules/utils/modal-utils.js
+++ b/src/renderer/modules/utils/modal-utils.js
@@ -1,20 +1,20 @@
 /**
  * Modal Utilities
- * 
+ *
  * Provides modal dialog utilities for the MxVoice Electron application
  */
 
 /**
  * Custom confirmation dialog
- * 
+ *
  * @param {string} message - The confirmation message
  * @param {string} title - The dialog title (default: 'Confirm')
  * @returns {Promise<boolean>} - Promise that resolves to true if confirmed, false if cancelled
  */
-export function customConfirm(message, title = 'Confirm') {
+export function customConfirm(message, title = "Confirm") {
   return new Promise((resolve) => {
-    const modal = document.createElement('div');
-    modal.className = 'modal fade';
+    const modal = document.createElement("div");
+    modal.className = "modal fade";
     modal.innerHTML = `
       <div class="modal-dialog">
         <div class="modal-content">
@@ -37,23 +37,23 @@ export function customConfirm(message, title = 'Confirm') {
 
     document.body.appendChild(modal);
 
-    const confirmBtn = modal.querySelector('.confirm-btn');
-    const closeBtn = modal.querySelector('.close');
-    const cancelBtn = modal.querySelector('.btn-secondary');
+    const confirmBtn = modal.querySelector(".confirm-btn");
+    const closeBtn = modal.querySelector(".close");
+    const cancelBtn = modal.querySelector(".btn-secondary");
 
     const cleanup = () => {
       // Hide the modal properly using Bootstrap
-      $(modal).modal('hide');
-      
+      $(modal).modal("hide");
+
       // Remove the modal backdrop
-      const backdrop = document.querySelector('.modal-backdrop');
+      const backdrop = document.querySelector(".modal-backdrop");
       if (backdrop) {
         backdrop.remove();
       }
-      
+
       // Remove modal-open class from body
-      document.body.classList.remove('modal-open');
-      
+      document.body.classList.remove("modal-open");
+
       // Remove the modal element
       setTimeout(() => {
         if (document.body.contains(modal)) {
@@ -62,95 +62,105 @@ export function customConfirm(message, title = 'Confirm') {
       }, 150); // Small delay to ensure Bootstrap animations complete
     };
 
-    confirmBtn.addEventListener('click', () => {
+    confirmBtn.addEventListener("click", () => {
       cleanup();
       resolve(true);
     });
 
-    closeBtn.addEventListener('click', () => {
+    closeBtn.addEventListener("click", () => {
       cleanup();
       resolve(false);
     });
 
-    cancelBtn.addEventListener('click', () => {
+    cancelBtn.addEventListener("click", () => {
       cleanup();
       resolve(false);
+    });
+
+    // Add keyboard event handlers for Escape key
+    document.addEventListener("keydown", function escapeHandler(e) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        document.removeEventListener("keydown", escapeHandler);
+        cleanup();
+        resolve(false);
+      }
     });
 
     // Show modal
-    $(modal).modal('show');
+    $(modal).modal("show");
   });
 }
 
 /**
  * Custom prompt dialog
- * 
+ *
  * @param {string} message - The prompt message
  * @param {string} defaultValue - The default input value
  * @param {string} title - The dialog title (default: 'Input')
  * @returns {Promise<string|null>} - Promise that resolves to the input value or null if cancelled
  */
-export function customPrompt(message, defaultValue = '', title = 'Input') {
+export function customPrompt(message, defaultValue = "", title = "Input") {
   return new Promise((resolve) => {
-    const modal = document.createElement('div');
-    modal.className = 'modal fade';
+    const modal = document.createElement("div");
+    modal.className = "modal fade";
     // Create modal structure safely without innerHTML
-    const modalDialog = document.createElement('div');
-    modalDialog.className = 'modal-dialog';
-    
-    const modalContent = document.createElement('div');
-    modalContent.className = 'modal-content';
-    
-    const modalHeader = document.createElement('div');
-    modalHeader.className = 'modal-header';
-    
-    const modalTitle = document.createElement('h5');
-    modalTitle.className = 'modal-title';
+    const modalDialog = document.createElement("div");
+    modalDialog.className = "modal-dialog";
+
+    const modalContent = document.createElement("div");
+    modalContent.className = "modal-content";
+
+    const modalHeader = document.createElement("div");
+    modalHeader.className = "modal-header";
+
+    const modalTitle = document.createElement("h5");
+    modalTitle.className = "modal-title";
     modalTitle.textContent = title;
-    
-    const closeBtn = document.createElement('button');
-    closeBtn.type = 'button';
-    closeBtn.className = 'close';
-    closeBtn.setAttribute('data-dismiss', 'modal');
-    
-    const closeSpan = document.createElement('span');
-    closeSpan.textContent = '×';
+
+    const closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.className = "close";
+    closeBtn.setAttribute("data-dismiss", "modal");
+
+    const closeSpan = document.createElement("span");
+    closeSpan.textContent = "×";
     closeBtn.appendChild(closeSpan);
-    
+
     modalHeader.appendChild(modalTitle);
     modalHeader.appendChild(closeBtn);
-    
-    const modalBody = document.createElement('div');
-    modalBody.className = 'modal-body';
-    
-    const messageP = document.createElement('p');
+
+    const modalBody = document.createElement("div");
+    modalBody.className = "modal-body";
+
+    const messageP = document.createElement("p");
     messageP.textContent = message;
-    
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.className = 'form-control prompt-input';
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "form-control prompt-input";
     input.value = defaultValue;
-    
+
     modalBody.appendChild(messageP);
     modalBody.appendChild(input);
-    
-    const modalFooter = document.createElement('div');
-    modalFooter.className = 'modal-footer';
-    
-    const cancelBtn = document.createElement('button');
-    cancelBtn.type = 'button';
-    cancelBtn.className = 'btn btn-secondary';
-    cancelBtn.setAttribute('data-dismiss', 'modal');
-    cancelBtn.textContent = 'Cancel';
-    
-    const confirmBtn = document.createElement('button');
-    confirmBtn.type = 'button';
-    confirmBtn.className = 'btn btn-primary confirm-btn';
-    confirmBtn.textContent = 'OK';
-    
+
+    const modalFooter = document.createElement("div");
+    modalFooter.className = "modal-footer";
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.type = "button";
+    cancelBtn.className = "btn btn-secondary";
+    cancelBtn.setAttribute("data-dismiss", "modal");
+    cancelBtn.textContent = "Cancel";
+
+    const confirmBtn = document.createElement("button");
+    confirmBtn.type = "button";
+    confirmBtn.className = "btn btn-primary confirm-btn";
+    confirmBtn.textContent = "OK";
+
     modalFooter.appendChild(cancelBtn);
     modalFooter.appendChild(confirmBtn);
-    
+
     modalContent.appendChild(modalHeader);
     modalContent.appendChild(modalBody);
     modalContent.appendChild(modalFooter);
@@ -162,17 +172,17 @@ export function customPrompt(message, defaultValue = '', title = 'Input') {
     // Use the already created element references instead of querying again
     const cleanup = () => {
       // Hide the modal properly using Bootstrap
-      $(modal).modal('hide');
-      
+      $(modal).modal("hide");
+
       // Remove the modal backdrop
-      const backdrop = document.querySelector('.modal-backdrop');
+      const backdrop = document.querySelector(".modal-backdrop");
       if (backdrop) {
         backdrop.remove();
       }
-      
+
       // Remove modal-open class from body
-      document.body.classList.remove('modal-open');
-      
+      document.body.classList.remove("modal-open");
+
       // Remove the modal element
       setTimeout(() => {
         if (document.body.contains(modal)) {
@@ -181,7 +191,7 @@ export function customPrompt(message, defaultValue = '', title = 'Input') {
       }, 150); // Small delay to ensure Bootstrap animations complete
     };
 
-    confirmBtn.addEventListener('click', () => {
+    confirmBtn.addEventListener("click", () => {
       const value = input.value.trim();
       cleanup();
       resolve(value || null);
@@ -189,14 +199,28 @@ export function customPrompt(message, defaultValue = '', title = 'Input') {
 
     // Note: closeBtn is not created in this function, so we'll handle it differently
     // The modal will be closed via Bootstrap's data-dismiss attribute
-    
-    cancelBtn.addEventListener('click', () => {
+
+    cancelBtn.addEventListener("click", () => {
       cleanup();
       resolve(null);
     });
 
+    // Add keyboard event handlers
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        const value = input.value.trim();
+        cleanup();
+        resolve(value || null);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        cleanup();
+        resolve(null);
+      }
+    });
+
     // Focus input, select text, and show modal
-    $(modal).modal('show');
+    $(modal).modal("show");
     setTimeout(() => {
       input.focus();
       input.select(); // Select all text so user can type over it
@@ -206,10 +230,10 @@ export function customPrompt(message, defaultValue = '', title = 'Input') {
 
 /**
  * Restore focus to search input
- * 
+ *
  * @param {string} selector - The search input selector (default: '#search-input')
  */
-export function restoreFocusToSearch(selector = '#search-input') {
+export function restoreFocusToSearch(selector = "#search-input") {
   const searchInput = document.querySelector(selector);
   if (searchInput) {
     searchInput.focus();
@@ -220,5 +244,5 @@ export function restoreFocusToSearch(selector = '#search-input') {
 export default {
   customConfirm,
   customPrompt,
-  restoreFocusToSearch
-}; 
+  restoreFocusToSearch,
+};


### PR DESCRIPTION
There were multiple double-click handlers attached to editing tab names, which meant that double-clicking on a tab to edit would pop up the edit modal twice. This fixes that by removing one of the handlers.

In addition, this makes the enter key work in modals, to trigger save.

In addition, this makes the Esc key work in modals, to trigger cancel (without stopping the current track from playing).