### PR TITLE
Multi-Profile Support with Launcher Window

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -502,6 +502,10 @@
             <form onsubmit="savePreferences(event)">
               <fieldset>
                 <legend>Data Locations</legend>
+                <div class="alert alert-info mb-3" role="alert">
+                  <i class="fas fa-info-circle"></i> <strong>Shared Across All Profiles:</strong> 
+                  These directory locations are shared by all profiles and will affect every user.
+                </div>
                 <div class="row g-2 mb-3">
                   <label for="preferences-database-directory" class="col-sm-3 col-form-label">Database File Location</label>
                   <div class="col-sm-6">

--- a/src/index.html
+++ b/src/index.html
@@ -114,10 +114,8 @@
               <div class="header-button">
                 <i class="fas fa-search"></i> Search
               </div>
-              <div class="icon-bar">
-                <a href="#">
-                  <!-- Icons could go here -->
-                </a>
+              <div id="profile-indicator" class="profile-indicator" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Current Profile">
+                <i class="fas fa-user"></i> <span id="profile-name">Loading...</span>
               </div>
             </h6>
             <div class="card-body">

--- a/src/launcher.html
+++ b/src/launcher.html
@@ -228,6 +228,67 @@
       40% { content: '..'; }
       60%, 100% { content: '...'; }
     }
+
+    /* Modal styles */
+    .modal-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.7);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1000;
+    }
+
+    .modal-content {
+      background: white;
+      padding: 30px;
+      border-radius: 12px;
+      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+      min-width: 400px;
+    }
+
+    .modal-content h2 {
+      margin: 0 0 20px 0;
+      color: #333;
+      font-size: 22px;
+    }
+
+    .form-group {
+      margin-bottom: 20px;
+    }
+
+    .form-group label {
+      display: block;
+      margin-bottom: 8px;
+      color: #555;
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .form-group input {
+      width: 100%;
+      padding: 10px;
+      border: 2px solid #ddd;
+      border-radius: 6px;
+      font-size: 15px;
+      transition: border-color 0.2s;
+    }
+
+    .form-group input:focus {
+      outline: none;
+      border-color: #667eea;
+    }
+
+    .modal-actions {
+      display: flex;
+      gap: 12px;
+      justify-content: flex-end;
+      margin-top: 24px;
+    }
   </style>
 </head>
 <body>
@@ -256,6 +317,27 @@
           </button>
         </div>
       </div>
+    </div>
+  </div>
+
+  <!-- Create Profile Modal -->
+  <div id="create-modal" class="modal-overlay" style="display: none;">
+    <div class="modal-content">
+      <h2>Create New Profile</h2>
+      <form id="create-form">
+        <div class="form-group">
+          <label for="profile-name-input">Profile Name:</label>
+          <input type="text" id="profile-name-input" required autofocus />
+        </div>
+        <div class="form-group">
+          <label for="profile-desc-input">Description (optional):</label>
+          <input type="text" id="profile-desc-input" />
+        </div>
+        <div class="modal-actions">
+          <button type="submit" class="btn btn-primary">Create</button>
+          <button type="button" id="cancel-create-btn" class="btn btn-secondary">Cancel</button>
+        </div>
+      </form>
     </div>
   </div>
 

--- a/src/launcher.html
+++ b/src/launcher.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'">
+  <title>Mx. Voice - Profile Launcher</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      padding: 20px;
+      color: #333;
+    }
+
+    .launcher-container {
+      background: white;
+      border-radius: 16px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+      width: 100%;
+      overflow: hidden;
+    }
+
+    .launcher-header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 30px;
+      text-align: center;
+    }
+
+    .launcher-header h1 {
+      font-size: 28px;
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+
+    .launcher-header p {
+      font-size: 14px;
+      opacity: 0.9;
+    }
+
+    .launcher-body {
+      padding: 30px;
+    }
+
+    .profile-list {
+      list-style: none;
+      margin-bottom: 20px;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    .profile-item {
+      background: #f8f9fa;
+      border: 2px solid transparent;
+      border-radius: 12px;
+      padding: 16px;
+      margin-bottom: 10px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .profile-item:hover {
+      background: #e9ecef;
+      border-color: #667eea;
+      transform: translateX(4px);
+    }
+
+    .profile-item.selected {
+      background: #e7eaf6;
+      border-color: #667eea;
+    }
+
+    .profile-info {
+      flex: 1;
+    }
+
+    .profile-name {
+      font-size: 16px;
+      font-weight: 600;
+      color: #333;
+      margin-bottom: 4px;
+    }
+
+    .profile-description {
+      font-size: 13px;
+      color: #666;
+    }
+
+    .profile-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .profile-delete {
+      background: #dc3545;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      padding: 6px 12px;
+      font-size: 12px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    .profile-delete:hover {
+      background: #c82333;
+    }
+
+    .profile-delete:disabled {
+      background: #ccc;
+      cursor: not-allowed;
+    }
+
+    .launcher-actions {
+      display: flex;
+      gap: 12px;
+      margin-top: 20px;
+    }
+
+    .btn {
+      flex: 1;
+      padding: 14px 24px;
+      border: none;
+      border-radius: 10px;
+      font-size: 15px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      text-align: center;
+    }
+
+    .btn-primary {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+    }
+
+    .btn-primary:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+    }
+
+    .btn-primary:disabled {
+      background: #ccc;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: none;
+    }
+
+    .btn-secondary {
+      background: white;
+      color: #667eea;
+      border: 2px solid #667eea;
+    }
+
+    .btn-secondary:hover {
+      background: #f8f9fa;
+      transform: translateY(-2px);
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 40px 20px;
+      color: #666;
+    }
+
+    .empty-state p {
+      margin-bottom: 20px;
+      font-size: 15px;
+    }
+
+    .error-message {
+      background: #f8d7da;
+      border: 1px solid #f5c6cb;
+      color: #721c24;
+      padding: 12px;
+      border-radius: 8px;
+      margin-bottom: 16px;
+      font-size: 14px;
+    }
+
+    /* Scrollbar styling */
+    .profile-list::-webkit-scrollbar {
+      width: 8px;
+    }
+
+    .profile-list::-webkit-scrollbar-track {
+      background: #f1f1f1;
+      border-radius: 10px;
+    }
+
+    .profile-list::-webkit-scrollbar-thumb {
+      background: #667eea;
+      border-radius: 10px;
+    }
+
+    .profile-list::-webkit-scrollbar-thumb:hover {
+      background: #764ba2;
+    }
+
+    .loading {
+      text-align: center;
+      padding: 40px;
+      color: #666;
+    }
+
+    .loading::after {
+      content: '...';
+      animation: dots 1.5s steps(4, end) infinite;
+    }
+
+    @keyframes dots {
+      0%, 20% { content: '.'; }
+      40% { content: '..'; }
+      60%, 100% { content: '...'; }
+    }
+  </style>
+</head>
+<body>
+  <div class="launcher-container">
+    <div class="launcher-header">
+      <h1>🎵 Mx. Voice</h1>
+      <p>Select your profile to continue</p>
+    </div>
+
+    <div class="launcher-body">
+      <div id="error-container"></div>
+      
+      <div id="loading-state" class="loading">
+        Loading profiles
+      </div>
+
+      <div id="profile-content" style="display: none;">
+        <ul id="profile-list" class="profile-list"></ul>
+
+        <div class="launcher-actions">
+          <button id="launch-btn" class="btn btn-primary" disabled>
+            Launch App
+          </button>
+          <button id="create-btn" class="btn btn-secondary">
+            + New Profile
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="launcher.js"></script>
+</body>
+</html>
+

--- a/src/launcher.html
+++ b/src/launcher.html
@@ -12,19 +12,55 @@
       box-sizing: border-box;
     }
 
+    :root {
+      --bg-gradient-start: #667eea;
+      --bg-gradient-end: #764ba2;
+      --container-bg: #ffffff;
+      --text-primary: #333333;
+      --text-secondary: #666666;
+      --item-bg: #f8f9fa;
+      --item-hover-bg: #e9ecef;
+      --item-selected-bg: #e7eaf6;
+      --border-color: #ddd;
+      --error-bg: #f8d7da;
+      --error-border: #f5c6cb;
+      --error-text: #721c24;
+      --modal-bg: #ffffff;
+      --scrollbar-track: #f1f1f1;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-gradient-start: #2d3748;
+        --bg-gradient-end: #1a202c;
+        --container-bg: #2d3748;
+        --text-primary: #f7fafc;
+        --text-secondary: #cbd5e0;
+        --item-bg: #1a202c;
+        --item-hover-bg: #374151;
+        --item-selected-bg: #4a5568;
+        --border-color: #4a5568;
+        --error-bg: #7f1d1d;
+        --error-border: #991b1b;
+        --error-text: #fecaca;
+        --modal-bg: #1a202c;
+        --scrollbar-track: #1a202c;
+      }
+    }
+
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      background: linear-gradient(135deg, var(--bg-gradient-start) 0%, var(--bg-gradient-end) 100%);
       display: flex;
       justify-content: center;
       align-items: center;
       min-height: 100vh;
       padding: 20px;
-      color: #333;
+      color: var(--text-primary);
     }
 
     .launcher-container {
-      background: white;
+      background: var(--container-bg);
       border-radius: 16px;
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
       max-width: 500px;
@@ -33,7 +69,7 @@
     }
 
     .launcher-header {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      background: linear-gradient(135deg, var(--bg-gradient-start) 0%, var(--bg-gradient-end) 100%);
       color: white;
       padding: 30px;
       text-align: center;
@@ -62,8 +98,8 @@
     }
 
     .profile-item {
-      background: #f8f9fa;
-      border: 2px solid transparent;
+      background: var(--item-bg);
+      border: 2px solid var(--border-color);
       border-radius: 12px;
       padding: 16px;
       margin-bottom: 10px;
@@ -73,16 +109,21 @@
       justify-content: space-between;
       align-items: center;
     }
+    
+    @media (prefers-color-scheme: light) {
+      .profile-item {
+        border-color: transparent;
+      }
+    }
 
     .profile-item:hover {
-      background: #e9ecef;
-      border-color: #667eea;
-      transform: translateX(4px);
+      background: var(--item-hover-bg);
+      border-color: var(--bg-gradient-start);
     }
 
     .profile-item.selected {
-      background: #e7eaf6;
-      border-color: #667eea;
+      background: var(--item-selected-bg);
+      border-color: var(--bg-gradient-start);
     }
 
     .profile-info {
@@ -92,13 +133,13 @@
     .profile-name {
       font-size: 16px;
       font-weight: 600;
-      color: #333;
+      color: var(--text-primary);
       margin-bottom: 4px;
     }
 
     .profile-description {
       font-size: 13px;
-      color: #666;
+      color: var(--text-secondary);
     }
 
     .profile-actions {
@@ -150,7 +191,6 @@
     }
 
     .btn-primary:hover {
-      transform: translateY(-2px);
       box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
     }
 
@@ -162,20 +202,32 @@
     }
 
     .btn-secondary {
-      background: white;
-      color: #667eea;
-      border: 2px solid #667eea;
+      background: transparent;
+      color: white;
+      border: 2px solid rgba(255, 255, 255, 0.3);
     }
 
     .btn-secondary:hover {
-      background: #f8f9fa;
-      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.1);
+      border-color: rgba(255, 255, 255, 0.5);
+    }
+    
+    @media (prefers-color-scheme: light) {
+      .btn-secondary {
+        color: var(--bg-gradient-start);
+        border-color: var(--bg-gradient-start);
+      }
+      
+      .btn-secondary:hover {
+        background: var(--item-bg);
+        border-color: var(--bg-gradient-start);
+      }
     }
 
     .empty-state {
       text-align: center;
       padding: 40px 20px;
-      color: #666;
+      color: var(--text-secondary);
     }
 
     .empty-state p {
@@ -184,9 +236,9 @@
     }
 
     .error-message {
-      background: #f8d7da;
-      border: 1px solid #f5c6cb;
-      color: #721c24;
+      background: var(--error-bg);
+      border: 1px solid var(--error-border);
+      color: var(--error-text);
       padding: 12px;
       border-radius: 8px;
       margin-bottom: 16px;
@@ -199,23 +251,23 @@
     }
 
     .profile-list::-webkit-scrollbar-track {
-      background: #f1f1f1;
+      background: var(--scrollbar-track);
       border-radius: 10px;
     }
 
     .profile-list::-webkit-scrollbar-thumb {
-      background: #667eea;
+      background: var(--bg-gradient-start);
       border-radius: 10px;
     }
 
     .profile-list::-webkit-scrollbar-thumb:hover {
-      background: #764ba2;
+      background: var(--bg-gradient-end);
     }
 
     .loading {
       text-align: center;
       padding: 40px;
-      color: #666;
+      color: var(--text-secondary);
     }
 
     .loading::after {
@@ -244,7 +296,7 @@
     }
 
     .modal-content {
-      background: white;
+      background: var(--modal-bg);
       padding: 30px;
       border-radius: 12px;
       box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
@@ -253,7 +305,7 @@
 
     .modal-content h2 {
       margin: 0 0 20px 0;
-      color: #333;
+      color: var(--text-primary);
       font-size: 22px;
     }
 
@@ -264,7 +316,7 @@
     .form-group label {
       display: block;
       margin-bottom: 8px;
-      color: #555;
+      color: var(--text-secondary);
       font-weight: 600;
       font-size: 14px;
     }
@@ -272,15 +324,17 @@
     .form-group input {
       width: 100%;
       padding: 10px;
-      border: 2px solid #ddd;
+      border: 2px solid var(--border-color);
       border-radius: 6px;
       font-size: 15px;
       transition: border-color 0.2s;
+      background: var(--container-bg);
+      color: var(--text-primary);
     }
 
     .form-group input:focus {
       outline: none;
-      border-color: #667eea;
+      border-color: var(--bg-gradient-start);
     }
 
     .modal-actions {

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -155,23 +155,56 @@ async function launchApp() {
 }
 
 /**
+ * Show create profile modal
+ */
+function showCreateModal() {
+  const modal = document.getElementById('create-modal');
+  const nameInput = document.getElementById('profile-name-input');
+  const descInput = document.getElementById('profile-desc-input');
+  
+  // Clear inputs
+  nameInput.value = '';
+  descInput.value = '';
+  
+  // Show modal
+  modal.style.display = 'flex';
+  
+  // Focus name input
+  setTimeout(() => nameInput.focus(), 100);
+}
+
+/**
+ * Hide create profile modal
+ */
+function hideCreateModal() {
+  const modal = document.getElementById('create-modal');
+  modal.style.display = 'none';
+}
+
+/**
  * Create a new profile
  */
-async function createNewProfile() {
-  const name = prompt('Enter profile name:');
+async function createNewProfile(event) {
+  event.preventDefault();
   
-  if (!name || !name.trim()) {
+  const nameInput = document.getElementById('profile-name-input');
+  const descInput = document.getElementById('profile-desc-input');
+  
+  const name = nameInput.value.trim();
+  const description = descInput.value.trim();
+  
+  if (!name) {
+    showError('Profile name is required');
     return;
   }
   
-  const description = prompt('Enter profile description (optional):') || '';
-  
   try {
-    const result = await window.launcherAPI.createProfile(name.trim(), description.trim());
+    const result = await window.launcherAPI.createProfile(name, description);
     
     if (result.success) {
+      hideCreateModal();
       await loadProfiles();
-      selectProfile(name.trim());
+      selectProfile(name);
       clearError();
     } else {
       showError(result.error || 'Failed to create profile');
@@ -216,12 +249,29 @@ async function deleteProfile(profileName) {
  */
 function setupEventListeners() {
   document.getElementById('launch-btn').addEventListener('click', launchApp);
-  document.getElementById('create-btn').addEventListener('click', createNewProfile);
+  document.getElementById('create-btn').addEventListener('click', showCreateModal);
+  document.getElementById('cancel-create-btn').addEventListener('click', hideCreateModal);
+  document.getElementById('create-form').addEventListener('submit', createNewProfile);
   
-  // Enter key launches app if profile selected
+  // Enter key launches app if profile selected (only when modal is not open)
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' && selectedProfile) {
+    const modal = document.getElementById('create-modal');
+    const modalOpen = modal.style.display === 'flex';
+    
+    if (e.key === 'Enter' && selectedProfile && !modalOpen) {
       launchApp();
+    }
+    
+    // Escape key closes modal
+    if (e.key === 'Escape' && modalOpen) {
+      hideCreateModal();
+    }
+  });
+  
+  // Click outside modal to close
+  document.getElementById('create-modal').addEventListener('click', (e) => {
+    if (e.target.id === 'create-modal') {
+      hideCreateModal();
     }
   });
 }

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -1,0 +1,252 @@
+/**
+ * Profile Launcher Renderer Script
+ * 
+ * This script runs in the launcher window and handles:
+ * - Displaying available profiles
+ * - Profile selection
+ * - Creating new profiles
+ * - Deleting profiles
+ * - Launching the main app with selected profile
+ */
+
+let selectedProfile = null;
+let profiles = [];
+
+// Wait for the secure API to be available
+window.addEventListener('DOMContentLoaded', async () => {
+  await loadProfiles();
+  setupEventListeners();
+});
+
+/**
+ * Load profiles from main process
+ */
+async function loadProfiles() {
+  try {
+    const result = await window.launcherAPI.getProfiles();
+    
+    if (result.success) {
+      profiles = result.profiles;
+      renderProfiles();
+      
+      // Hide loading, show content
+      document.getElementById('loading-state').style.display = 'none';
+      document.getElementById('profile-content').style.display = 'block';
+      
+      // Auto-select first profile if only one exists
+      if (profiles.length === 1) {
+        selectProfile(profiles[0].name);
+      }
+    } else {
+      showError(result.error || 'Failed to load profiles');
+    }
+  } catch (error) {
+    showError(`Error loading profiles: ${error.message}`);
+  }
+}
+
+/**
+ * Render profiles in the list
+ */
+function renderProfiles() {
+  const listElement = document.getElementById('profile-list');
+  listElement.innerHTML = '';
+  
+  if (profiles.length === 0) {
+    listElement.innerHTML = `
+      <div class="empty-state">
+        <p>No profiles found. Create your first profile to get started.</p>
+      </div>
+    `;
+    return;
+  }
+  
+  // Sort profiles by last used (most recent first)
+  const sortedProfiles = [...profiles].sort((a, b) => b.last_used - a.last_used);
+  
+  sortedProfiles.forEach(profile => {
+    const li = document.createElement('li');
+    li.className = 'profile-item';
+    li.dataset.profileName = profile.name;
+    
+    if (selectedProfile === profile.name) {
+      li.classList.add('selected');
+    }
+    
+    li.innerHTML = `
+      <div class="profile-info">
+        <div class="profile-name">${escapeHtml(profile.name)}</div>
+        <div class="profile-description">${escapeHtml(profile.description || 'No description')}</div>
+      </div>
+      <div class="profile-actions">
+        ${profiles.length > 1 && profile.name !== 'Default User' ? `
+          <button class="profile-delete" data-profile="${escapeHtml(profile.name)}">Delete</button>
+        ` : ''}
+      </div>
+    `;
+    
+    // Click to select profile
+    li.addEventListener('click', (e) => {
+      if (!e.target.classList.contains('profile-delete')) {
+        selectProfile(profile.name);
+      }
+    });
+    
+    // Double-click to launch
+    li.addEventListener('dblclick', (e) => {
+      if (!e.target.classList.contains('profile-delete')) {
+        launchApp();
+      }
+    });
+    
+    listElement.appendChild(li);
+  });
+  
+  // Setup delete button handlers
+  document.querySelectorAll('.profile-delete').forEach(btn => {
+    btn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const profileName = btn.dataset.profile;
+      await deleteProfile(profileName);
+    });
+  });
+}
+
+/**
+ * Select a profile
+ */
+function selectProfile(profileName) {
+  selectedProfile = profileName;
+  
+  // Update UI
+  document.querySelectorAll('.profile-item').forEach(item => {
+    if (item.dataset.profileName === profileName) {
+      item.classList.add('selected');
+    } else {
+      item.classList.remove('selected');
+    }
+  });
+  
+  // Enable launch button
+  document.getElementById('launch-btn').disabled = false;
+}
+
+/**
+ * Launch the main app with selected profile
+ */
+async function launchApp() {
+  if (!selectedProfile) {
+    showError('Please select a profile');
+    return;
+  }
+  
+  try {
+    const result = await window.launcherAPI.launchApp(selectedProfile);
+    
+    if (result.success) {
+      // Main app is launching, close launcher window
+      window.close();
+    } else {
+      showError(result.error || 'Failed to launch app');
+    }
+  } catch (error) {
+    showError(`Error launching app: ${error.message}`);
+  }
+}
+
+/**
+ * Create a new profile
+ */
+async function createNewProfile() {
+  const name = prompt('Enter profile name:');
+  
+  if (!name || !name.trim()) {
+    return;
+  }
+  
+  const description = prompt('Enter profile description (optional):') || '';
+  
+  try {
+    const result = await window.launcherAPI.createProfile(name.trim(), description.trim());
+    
+    if (result.success) {
+      await loadProfiles();
+      selectProfile(name.trim());
+      clearError();
+    } else {
+      showError(result.error || 'Failed to create profile');
+    }
+  } catch (error) {
+    showError(`Error creating profile: ${error.message}`);
+  }
+}
+
+/**
+ * Delete a profile
+ */
+async function deleteProfile(profileName) {
+  const confirmed = confirm(`Are you sure you want to delete the profile "${profileName}"?\n\nThis will remove all preferences for this profile.`);
+  
+  if (!confirmed) {
+    return;
+  }
+  
+  try {
+    const result = await window.launcherAPI.deleteProfile(profileName);
+    
+    if (result.success) {
+      // If deleted profile was selected, clear selection
+      if (selectedProfile === profileName) {
+        selectedProfile = null;
+        document.getElementById('launch-btn').disabled = true;
+      }
+      
+      await loadProfiles();
+      clearError();
+    } else {
+      showError(result.error || 'Failed to delete profile');
+    }
+  } catch (error) {
+    showError(`Error deleting profile: ${error.message}`);
+  }
+}
+
+/**
+ * Setup event listeners
+ */
+function setupEventListeners() {
+  document.getElementById('launch-btn').addEventListener('click', launchApp);
+  document.getElementById('create-btn').addEventListener('click', createNewProfile);
+  
+  // Enter key launches app if profile selected
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && selectedProfile) {
+      launchApp();
+    }
+  });
+}
+
+/**
+ * Show error message
+ */
+function showError(message) {
+  const container = document.getElementById('error-container');
+  container.innerHTML = `<div class="error-message">${escapeHtml(message)}</div>`;
+}
+
+/**
+ * Clear error message
+ */
+function clearError() {
+  document.getElementById('error-container').innerHTML = '';
+}
+
+/**
+ * Escape HTML to prevent XSS
+ */
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+

--- a/src/main/index-modular.js
+++ b/src/main/index-modular.js
@@ -97,6 +97,8 @@ export function getProfileDirectory(type) {
       return path.join(profilesDir, sanitized, 'hotkeys');
     case 'holding-tank':
       return path.join(profilesDir, sanitized, 'holding-tank');
+    case 'state':
+      return path.join(profilesDir, sanitized);
     case 'preferences':
       return path.join(profilesDir, sanitized);
     default:

--- a/src/main/modules/app-setup.js
+++ b/src/main/modules/app-setup.js
@@ -346,6 +346,17 @@ function createApplicationMenu() {
             closeAllTabs();
           },
         },
+        { type: "separator" },
+        {
+          label: "Switch Profile...",
+          click: async () => {
+            // Import main module to trigger profile switch
+            const mainModule = await import('../index-modular.js');
+            // Relaunch without profile argument to show launcher
+            app.relaunch({ args: process.argv.slice(1).filter(arg => !arg.startsWith('--profile=')) });
+            app.exit(0);
+          },
+        },
       ],
     },
     {

--- a/src/main/modules/ipc-handlers.js
+++ b/src/main/modules/ipc-handlers.js
@@ -1381,10 +1381,53 @@ function registerAllHandlers() {
     }
   });
 
+  // Profile handlers
+  ipcMain.handle('profile:get-current', async () => {
+    try {
+      // Import the main module to get current profile
+      const mainModule = await import('../index-modular.js');
+      const profile = mainModule.getCurrentProfile();
+      return { success: true, profile };
+    } catch (error) {
+      debugLog?.error('Get current profile error:', { module: 'ipc-handlers', function: 'profile:get-current', error: error.message });
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('profile:get-directory', async (event, type) => {
+    try {
+      // Import the main module to get profile directory
+      const mainModule = await import('../index-modular.js');
+      const directory = mainModule.getProfileDirectory(type);
+      return { success: true, directory };
+    } catch (error) {
+      debugLog?.error('Get profile directory error:', { module: 'ipc-handlers', function: 'profile:get-directory', error: error.message });
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('profile:switch', async () => {
+    try {
+      // Close main window and relaunch launcher
+      if (mainWindow) {
+        mainWindow.close();
+      }
+      
+      // Relaunch the app without profile argument to show launcher
+      app.relaunch({ args: process.argv.slice(1).filter(arg => !arg.startsWith('--profile=')) });
+      app.exit(0);
+      
+      return { success: true };
+    } catch (error) {
+      debugLog?.error('Profile switch error:', { module: 'ipc-handlers', function: 'profile:switch', error: error.message });
+      return { success: false, error: error.message };
+    }
+  });
+
   debugLog?.info('✅ Secure IPC handlers registered successfully', { 
     module: 'ipc-handlers', 
     function: 'registerAllHandlers',
-    secureHandlersCount: 50
+    secureHandlersCount: 53
   });
 
   debugLog?.info('✅ All IPC handlers registered successfully (context isolation ready)', { 

--- a/src/main/modules/launcher-window.js
+++ b/src/main/modules/launcher-window.js
@@ -1,0 +1,227 @@
+/**
+ * Profile Launcher Window Module
+ * 
+ * Handles the profile launcher window that shows on startup.
+ * Allows users to select/create/delete profiles before launching the main app.
+ */
+
+import { BrowserWindow, ipcMain } from 'electron';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Get __dirname equivalent for ES6 modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let debugLog = null;
+let profileManager = null;
+let launcherWindow = null;
+let mainAppLauncher = null;
+
+/**
+ * Initialize the launcher window module
+ * @param {Object} dependencies - Module dependencies
+ */
+function initializeLauncherWindow(dependencies) {
+  debugLog = dependencies.debugLog;
+  profileManager = dependencies.profileManager;
+  mainAppLauncher = dependencies.mainAppLauncher;
+  
+  debugLog?.info('Launcher window module initialized', { 
+    module: 'launcher-window',
+    function: 'initializeLauncherWindow' 
+  });
+  
+  // Register IPC handlers for launcher
+  registerLauncherHandlers();
+}
+
+/**
+ * Create and show the launcher window
+ * @returns {Promise<BrowserWindow>} The launcher window
+ */
+async function createLauncherWindow() {
+  if (launcherWindow) {
+    launcherWindow.focus();
+    return launcherWindow;
+  }
+  
+  debugLog?.info('Creating launcher window', { 
+    module: 'launcher-window',
+    function: 'createLauncherWindow' 
+  });
+  
+  launcherWindow = new BrowserWindow({
+    width: 550,
+    height: 650,
+    resizable: false,
+    center: true,
+    titleBarStyle: 'hiddenInset',
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, '..', '..', 'preload', 'launcher-preload.js')
+    }
+  });
+  
+  // Load the launcher HTML
+  const launcherHtmlPath = path.join(__dirname, '..', '..', 'launcher.html');
+  await launcherWindow.loadFile(launcherHtmlPath);
+  
+  // Open DevTools in development (disabled by default)
+  // Uncomment to enable DevTools for debugging the launcher
+  // if (process.env.NODE_ENV === 'development' || !process.env.NODE_ENV) {
+  //   launcherWindow.webContents.openDevTools({ mode: 'detach' });
+  // }
+  
+  // Clean up on close
+  launcherWindow.on('closed', () => {
+    debugLog?.info('Launcher window closed', { 
+      module: 'launcher-window',
+      function: 'createLauncherWindow' 
+    });
+    launcherWindow = null;
+  });
+  
+  return launcherWindow;
+}
+
+/**
+ * Close the launcher window
+ */
+function closeLauncherWindow() {
+  if (launcherWindow) {
+    launcherWindow.close();
+    launcherWindow = null;
+  }
+}
+
+/**
+ * Register IPC handlers for launcher operations
+ */
+function registerLauncherHandlers() {
+  // Get all profiles
+  ipcMain.handle('launcher:get-profiles', async () => {
+    try {
+      const profiles = profileManager.getAvailableProfiles();
+      
+      debugLog?.info('Launcher: Retrieved profiles', { 
+        module: 'launcher-window',
+        function: 'launcher:get-profiles',
+        count: profiles.length 
+      });
+      
+      return { success: true, profiles };
+    } catch (error) {
+      debugLog?.error('Launcher: Failed to get profiles', { 
+        module: 'launcher-window',
+        function: 'launcher:get-profiles',
+        error: error.message 
+      });
+      return { success: false, error: error.message };
+    }
+  });
+  
+  // Create new profile
+  ipcMain.handle('launcher:create-profile', async (event, name, description) => {
+    try {
+      debugLog?.info('Launcher: Creating profile', { 
+        module: 'launcher-window',
+        function: 'launcher:create-profile',
+        name 
+      });
+      
+      const result = profileManager.createProfile(name, description);
+      
+      if (result.success) {
+        debugLog?.info('Launcher: Profile created', { 
+          module: 'launcher-window',
+          function: 'launcher:create-profile',
+          name 
+        });
+      }
+      
+      return result;
+    } catch (error) {
+      debugLog?.error('Launcher: Failed to create profile', { 
+        module: 'launcher-window',
+        function: 'launcher:create-profile',
+        name,
+        error: error.message 
+      });
+      return { success: false, error: error.message };
+    }
+  });
+  
+  // Delete profile
+  ipcMain.handle('launcher:delete-profile', async (event, name) => {
+    try {
+      debugLog?.info('Launcher: Deleting profile', { 
+        module: 'launcher-window',
+        function: 'launcher:delete-profile',
+        name 
+      });
+      
+      const result = profileManager.deleteProfile(name);
+      
+      if (result.success) {
+        debugLog?.info('Launcher: Profile deleted', { 
+          module: 'launcher-window',
+          function: 'launcher:delete-profile',
+          name 
+        });
+      }
+      
+      return result;
+    } catch (error) {
+      debugLog?.error('Launcher: Failed to delete profile', { 
+        module: 'launcher-window',
+        function: 'launcher:delete-profile',
+        name,
+        error: error.message 
+      });
+      return { success: false, error: error.message };
+    }
+  });
+  
+  // Launch main app with profile
+  ipcMain.handle('launcher:launch-app', async (event, profileName) => {
+    try {
+      debugLog?.info('Launcher: Launching app with profile', { 
+        module: 'launcher-window',
+        function: 'launcher:launch-app',
+        profileName 
+      });
+      
+      // Update profile last used
+      profileManager.updateProfileLastUsed(profileName);
+      
+      // Launch main app with profile context
+      if (mainAppLauncher) {
+        await mainAppLauncher(profileName);
+        
+        // Close launcher window after main app launches
+        closeLauncherWindow();
+        
+        return { success: true };
+      } else {
+        throw new Error('Main app launcher not configured');
+      }
+    } catch (error) {
+      debugLog?.error('Launcher: Failed to launch app', { 
+        module: 'launcher-window',
+        function: 'launcher:launch-app',
+        profileName,
+        error: error.message 
+      });
+      return { success: false, error: error.message };
+    }
+  });
+}
+
+export {
+  initializeLauncherWindow,
+  createLauncherWindow,
+  closeLauncherWindow
+};
+

--- a/src/main/modules/launcher-window.js
+++ b/src/main/modules/launcher-window.js
@@ -103,7 +103,7 @@ function registerLauncherHandlers() {
   // Get all profiles
   ipcMain.handle('launcher:get-profiles', async () => {
     try {
-      const profiles = profileManager.getAvailableProfiles();
+      const profiles = await profileManager.getAvailableProfiles();
       
       debugLog?.info('Launcher: Retrieved profiles', { 
         module: 'launcher-window',
@@ -131,7 +131,7 @@ function registerLauncherHandlers() {
         name 
       });
       
-      const result = profileManager.createProfile(name, description);
+      const result = await profileManager.createProfile(name, description);
       
       if (result.success) {
         debugLog?.info('Launcher: Profile created', { 
@@ -162,7 +162,7 @@ function registerLauncherHandlers() {
         name 
       });
       
-      const result = profileManager.deleteProfile(name);
+      const result = await profileManager.deleteProfile(name);
       
       if (result.success) {
         debugLog?.info('Launcher: Profile deleted', { 

--- a/src/main/modules/profile-manager.js
+++ b/src/main/modules/profile-manager.js
@@ -1,0 +1,495 @@
+/**
+ * Profile Manager Module
+ * 
+ * Handles user profile creation, management, and storage.
+ * Profiles allow multiple users to have separate preferences while sharing the database.
+ * 
+ * Architecture:
+ * - Profiles are stored in userData/profiles/ directory
+ * - Each profile has a preferences.json file
+ * - Profile registry stored in userData/profiles.json
+ * - Main app launches with --profile="ProfileName" argument
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { app } from 'electron';
+import { fileURLToPath } from 'url';
+
+// Get __dirname equivalent for ES6 modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let debugLog = null;
+
+/**
+ * Initialize the Profile Manager
+ * @param {Object} dependencies - Module dependencies
+ */
+function initializeProfileManager(dependencies) {
+  debugLog = dependencies.debugLog;
+  
+  debugLog?.info('Profile Manager initialized', { 
+    module: 'profile-manager', 
+    function: 'initializeProfileManager' 
+  });
+  
+  // Ensure profiles directory exists
+  const profilesDir = getProfilesDirectory();
+  if (!fs.existsSync(profilesDir)) {
+    fs.mkdirSync(profilesDir, { recursive: true });
+    debugLog?.info('Created profiles directory', { 
+      module: 'profile-manager',
+      path: profilesDir 
+    });
+  }
+}
+
+/**
+ * Get the profiles directory path
+ * @returns {string} Path to profiles directory
+ */
+function getProfilesDirectory() {
+  return path.join(app.getPath('userData'), 'profiles');
+}
+
+/**
+ * Get the profile registry file path
+ * @returns {string} Path to profiles.json
+ */
+function getProfileRegistryPath() {
+  return path.join(app.getPath('userData'), 'profiles.json');
+}
+
+/**
+ * Get the profile preferences file path
+ * @param {string} profileName - Name of the profile
+ * @returns {string} Path to profile preferences file
+ */
+function getProfilePreferencesPath(profileName) {
+  const safeProfileName = sanitizeProfileName(profileName);
+  return path.join(getProfilesDirectory(), safeProfileName, 'preferences.json');
+}
+
+/**
+ * Sanitize profile name for filesystem safety
+ * @param {string} name - Profile name
+ * @returns {string} Sanitized name safe for filesystem
+ */
+function sanitizeProfileName(name) {
+  return name.replace(/[^a-zA-Z0-9\s\-_]/g, '').trim();
+}
+
+/**
+ * Get the default profile preferences structure
+ * @returns {Object} Default preferences object
+ */
+function getDefaultPreferences() {
+  return {
+    // Audio settings
+    fade_out_seconds: 2,
+    
+    // Appearance & UI
+    screen_mode: 'auto',
+    font_size: 11,
+    
+    // Debug & Updates
+    debug_log_enabled: false,
+    prerelease_updates: false,
+    
+    // UI State & Layout (stored per-profile)
+    holding_tank_mode: 'storage',
+    
+    // Metadata
+    created_at: Date.now(),
+    last_used: Date.now()
+  };
+}
+
+/**
+ * Load profile registry
+ * @returns {Object} Profile registry data
+ */
+function loadProfileRegistry() {
+  try {
+    const registryPath = getProfileRegistryPath();
+    
+    if (!fs.existsSync(registryPath)) {
+      // Create default registry with "Default User" profile
+      const defaultRegistry = {
+        profiles: {
+          'Default User': {
+            name: 'Default User',
+            description: 'Default profile',
+            created_at: Date.now(),
+            last_used: Date.now()
+          }
+        },
+        metadata: {
+          version: '1.0.0',
+          created_at: Date.now()
+        }
+      };
+      
+      // Save default registry
+      fs.writeFileSync(registryPath, JSON.stringify(defaultRegistry, null, 2));
+      debugLog?.info('Created default profile registry', { 
+        module: 'profile-manager',
+        function: 'loadProfileRegistry' 
+      });
+      
+      return defaultRegistry;
+    }
+    
+    const data = fs.readFileSync(registryPath, 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    debugLog?.error('Failed to load profile registry', { 
+      module: 'profile-manager', 
+      function: 'loadProfileRegistry',
+      error: error.message 
+    });
+    return {
+      profiles: {
+        'Default User': {
+          name: 'Default User',
+          description: 'Default profile',
+          created_at: Date.now(),
+          last_used: Date.now()
+        }
+      },
+      metadata: { version: '1.0.0', created_at: Date.now() }
+    };
+  }
+}
+
+/**
+ * Save profile registry
+ * @param {Object} registry - Profile registry data
+ * @returns {boolean} Success status
+ */
+function saveProfileRegistry(registry) {
+  try {
+    const registryPath = getProfileRegistryPath();
+    fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+    
+    debugLog?.info('Profile registry saved', { 
+      module: 'profile-manager', 
+      function: 'saveProfileRegistry',
+      profileCount: Object.keys(registry.profiles).length 
+    });
+    
+    return true;
+  } catch (error) {
+    debugLog?.error('Failed to save profile registry', { 
+      module: 'profile-manager', 
+      function: 'saveProfileRegistry',
+      error: error.message 
+    });
+    return false;
+  }
+}
+
+/**
+ * Get all available profiles
+ * @returns {Array} Array of profile objects
+ */
+function getAvailableProfiles() {
+  try {
+    const registry = loadProfileRegistry();
+    return Object.values(registry.profiles);
+  } catch (error) {
+    debugLog?.error('Failed to get available profiles', { 
+      module: 'profile-manager', 
+      function: 'getAvailableProfiles',
+      error: error.message 
+    });
+    return [];
+  }
+}
+
+/**
+ * Check if profile exists
+ * @param {string} profileName - Profile name to check
+ * @returns {boolean} Whether profile exists
+ */
+function profileExists(profileName) {
+  try {
+    const registry = loadProfileRegistry();
+    return profileName in registry.profiles;
+  } catch (error) {
+    debugLog?.error('Failed to check profile existence', { 
+      module: 'profile-manager', 
+      function: 'profileExists',
+      profileName,
+      error: error.message 
+    });
+    return false;
+  }
+}
+
+/**
+ * Validate profile name
+ * @param {string} name - Profile name to validate
+ * @returns {Object} Validation result { valid: boolean, error?: string }
+ */
+function validateProfileName(name) {
+  if (!name || typeof name !== 'string') {
+    return { valid: false, error: 'Profile name is required' };
+  }
+  
+  const trimmedName = name.trim();
+  if (trimmedName.length === 0) {
+    return { valid: false, error: 'Profile name cannot be empty' };
+  }
+  
+  if (trimmedName.length > 50) {
+    return { valid: false, error: 'Profile name cannot exceed 50 characters' };
+  }
+  
+  // Check for case-insensitive uniqueness
+  const profiles = getAvailableProfiles();
+  const existingProfile = profiles.find(p => 
+    p.name.toLowerCase() === trimmedName.toLowerCase()
+  );
+  
+  if (existingProfile) {
+    return { valid: false, error: 'Profile name already exists' };
+  }
+  
+  return { valid: true };
+}
+
+/**
+ * Create a new profile
+ * @param {string} profileName - Name for the new profile
+ * @param {string} description - Optional description
+ * @returns {Object} Result { success: boolean, error?: string }
+ */
+function createProfile(profileName, description = '') {
+  try {
+    // Validate profile name
+    const validation = validateProfileName(profileName);
+    if (!validation.valid) {
+      return { success: false, error: validation.error };
+    }
+    
+    // Load registry
+    const registry = loadProfileRegistry();
+    
+    // Create profile directory
+    const profileDir = path.join(getProfilesDirectory(), sanitizeProfileName(profileName));
+    if (!fs.existsSync(profileDir)) {
+      fs.mkdirSync(profileDir, { recursive: true });
+    }
+    
+    // Create profile preferences with defaults
+    const preferences = getDefaultPreferences();
+    
+    // Save profile preferences
+    const preferencesPath = getProfilePreferencesPath(profileName);
+    fs.writeFileSync(preferencesPath, JSON.stringify(preferences, null, 2));
+    
+    // Add to registry
+    registry.profiles[profileName] = {
+      name: profileName,
+      description: description,
+      created_at: Date.now(),
+      last_used: Date.now()
+    };
+    
+    // Save registry
+    saveProfileRegistry(registry);
+    
+    debugLog?.info('Profile created', { 
+      module: 'profile-manager', 
+      function: 'createProfile',
+      profileName
+    });
+    
+    return { success: true };
+  } catch (error) {
+    debugLog?.error('Failed to create profile', { 
+      module: 'profile-manager', 
+      function: 'createProfile',
+      profileName,
+      error: error.message 
+    });
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Update profile last used timestamp
+ * @param {string} profileName - Profile name
+ * @returns {boolean} Success status
+ */
+function updateProfileLastUsed(profileName) {
+  try {
+    const registry = loadProfileRegistry();
+    
+    if (registry.profiles[profileName]) {
+      registry.profiles[profileName].last_used = Date.now();
+      saveProfileRegistry(registry);
+    }
+    
+    return true;
+  } catch (error) {
+    debugLog?.error('Failed to update profile last used', { 
+      module: 'profile-manager', 
+      function: 'updateProfileLastUsed',
+      profileName,
+      error: error.message 
+    });
+    return false;
+  }
+}
+
+/**
+ * Delete a profile
+ * @param {string} profileName - Profile name to delete
+ * @returns {Object} Result { success: boolean, error?: string }
+ */
+function deleteProfile(profileName) {
+  try {
+    // Prevent deletion of Default User
+    if (profileName === 'Default User') {
+      return { success: false, error: 'Cannot delete Default User profile' };
+    }
+    
+    // Check if profile exists
+    if (!profileExists(profileName)) {
+      return { success: false, error: 'Profile does not exist' };
+    }
+    
+    // Get available profiles to ensure we don't delete the last one
+    const profiles = getAvailableProfiles();
+    if (profiles.length <= 1) {
+      return { success: false, error: 'Cannot delete the last profile' };
+    }
+    
+    // Load registry
+    const registry = loadProfileRegistry();
+    
+    // Remove from registry
+    delete registry.profiles[profileName];
+    
+    // Save registry
+    saveProfileRegistry(registry);
+    
+    // Remove profile directory
+    const profileDir = path.join(getProfilesDirectory(), sanitizeProfileName(profileName));
+    if (fs.existsSync(profileDir)) {
+      fs.rmSync(profileDir, { recursive: true, force: true });
+    }
+    
+    debugLog?.info('Profile deleted', { 
+      module: 'profile-manager', 
+      function: 'deleteProfile',
+      profileName 
+    });
+    
+    return { success: true };
+  } catch (error) {
+    debugLog?.error('Failed to delete profile', { 
+      module: 'profile-manager', 
+      function: 'deleteProfile',
+      profileName,
+      error: error.message 
+    });
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Load profile preferences
+ * @param {string} profileName - Profile name
+ * @returns {Object|null} Profile preferences or null if not found
+ */
+function loadProfilePreferences(profileName) {
+  try {
+    const preferencesPath = getProfilePreferencesPath(profileName);
+    
+    if (!fs.existsSync(preferencesPath)) {
+      // Create default preferences if they don't exist
+      const profileDir = path.dirname(preferencesPath);
+      if (!fs.existsSync(profileDir)) {
+        fs.mkdirSync(profileDir, { recursive: true });
+      }
+      
+      const preferences = getDefaultPreferences();
+      fs.writeFileSync(preferencesPath, JSON.stringify(preferences, null, 2));
+      
+      debugLog?.info('Created default preferences for profile', { 
+        module: 'profile-manager', 
+        function: 'loadProfilePreferences',
+        profileName 
+      });
+      
+      return preferences;
+    }
+    
+    const data = fs.readFileSync(preferencesPath, 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    debugLog?.error('Failed to load profile preferences', { 
+      module: 'profile-manager', 
+      function: 'loadProfilePreferences',
+      profileName,
+      error: error.message 
+    });
+    return null;
+  }
+}
+
+/**
+ * Save profile preferences
+ * @param {string} profileName - Profile name
+ * @param {Object} preferences - Preferences to save
+ * @returns {boolean} Success status
+ */
+function saveProfilePreferences(profileName, preferences) {
+  try {
+    const preferencesPath = getProfilePreferencesPath(profileName);
+    const profileDir = path.dirname(preferencesPath);
+    
+    // Ensure profile directory exists
+    if (!fs.existsSync(profileDir)) {
+      fs.mkdirSync(profileDir, { recursive: true });
+    }
+    
+    fs.writeFileSync(preferencesPath, JSON.stringify(preferences, null, 2));
+    
+    debugLog?.info('Profile preferences saved', { 
+      module: 'profile-manager', 
+      function: 'saveProfilePreferences',
+      profileName 
+    });
+    
+    return true;
+  } catch (error) {
+    debugLog?.error('Failed to save profile preferences', { 
+      module: 'profile-manager', 
+      function: 'saveProfilePreferences',
+      profileName,
+      error: error.message 
+    });
+    return false;
+  }
+}
+
+export {
+  initializeProfileManager,
+  getAvailableProfiles,
+  profileExists,
+  validateProfileName,
+  createProfile,
+  updateProfileLastUsed,
+  deleteProfile,
+  loadProfilePreferences,
+  saveProfilePreferences,
+  getDefaultPreferences,
+  getProfilesDirectory,
+  sanitizeProfileName
+};
+

--- a/src/main/modules/profile-manager.js
+++ b/src/main/modules/profile-manager.js
@@ -87,7 +87,7 @@ function sanitizeProfileName(name) {
 function getDefaultPreferences() {
   return {
     // Audio settings
-    fade_out_seconds: 2,
+    fade_out_seconds: 3,
     
     // Appearance & UI
     screen_mode: 'auto',

--- a/src/preload/launcher-preload.js
+++ b/src/preload/launcher-preload.js
@@ -1,0 +1,39 @@
+/**
+ * Launcher Window Preload Script
+ * 
+ * Exposes profile launcher API to renderer process with context isolation.
+ */
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+// Expose launcher API
+contextBridge.exposeInMainWorld('launcherAPI', {
+  /**
+   * Get all available profiles
+   * @returns {Promise<Object>} Result with profiles array
+   */
+  getProfiles: () => ipcRenderer.invoke('launcher:get-profiles'),
+  
+  /**
+   * Create a new profile
+   * @param {string} name - Profile name
+   * @param {string} description - Profile description
+   * @returns {Promise<Object>} Result with success status
+   */
+  createProfile: (name, description) => ipcRenderer.invoke('launcher:create-profile', name, description),
+  
+  /**
+   * Delete a profile
+   * @param {string} name - Profile name
+   * @returns {Promise<Object>} Result with success status
+   */
+  deleteProfile: (name) => ipcRenderer.invoke('launcher:delete-profile', name),
+  
+  /**
+   * Launch main app with selected profile
+   * @param {string} profileName - Profile to launch with
+   * @returns {Promise<Object>} Result with success status
+   */
+  launchApp: (profileName) => ipcRenderer.invoke('launcher:launch-app', profileName)
+});
+

--- a/src/preload/modules/secure-api-exposer.js
+++ b/src/preload/modules/secure-api-exposer.js
@@ -391,7 +391,10 @@ const secureElectronAPI = {
       getCurrent: () => ipcRenderer.invoke('profile:get-current'),
       getDirectory: (type) => ipcRenderer.invoke('profile:get-directory', type),
       switchProfile: () => ipcRenderer.invoke('profile:switch'),
-      saveState: (state) => ipcRenderer.invoke('profile:save-state', state)
+      saveState: (state) => ipcRenderer.invoke('profile:save-state', state),
+      getPreference: (key) => ipcRenderer.invoke('profile:get-preference', key),
+      setPreference: (key, value) => ipcRenderer.invoke('profile:set-preference', key, value),
+      getAllPreferences: () => ipcRenderer.invoke('profile:get-all-preferences')
     },
   
   // Utility functions

--- a/src/preload/modules/secure-api-exposer.js
+++ b/src/preload/modules/secure-api-exposer.js
@@ -386,6 +386,13 @@ const secureElectronAPI = {
     removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel)
   },
   
+  // Profile functions
+  profile: {
+    getCurrent: () => ipcRenderer.invoke('profile:get-current'),
+    getDirectory: (type) => ipcRenderer.invoke('profile:get-directory', type),
+    switchProfile: () => ipcRenderer.invoke('profile:switch')
+  },
+  
   // Utility functions
   utils: {
     generateId: () => ipcRenderer.invoke('generate-id'),

--- a/src/preload/modules/secure-api-exposer.js
+++ b/src/preload/modules/secure-api-exposer.js
@@ -386,12 +386,13 @@ const secureElectronAPI = {
     removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel)
   },
   
-  // Profile functions
-  profile: {
-    getCurrent: () => ipcRenderer.invoke('profile:get-current'),
-    getDirectory: (type) => ipcRenderer.invoke('profile:get-directory', type),
-    switchProfile: () => ipcRenderer.invoke('profile:switch')
-  },
+    // Profile functions
+    profile: {
+      getCurrent: () => ipcRenderer.invoke('profile:get-current'),
+      getDirectory: (type) => ipcRenderer.invoke('profile:get-directory', type),
+      switchProfile: () => ipcRenderer.invoke('profile:switch'),
+      saveState: (state) => ipcRenderer.invoke('profile:save-state', state)
+    },
   
   // Utility functions
   utils: {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -207,10 +207,38 @@ import AppInitialization from './renderer/modules/app-initialization/index.js';
       window.logInfo('Holding tank module made available on window object');
     }
     
+    // Make hotkeys module available
+    if (moduleRegistry.hotkeys) {
+      window.hotkeysModule = moduleRegistry.hotkeys;
+      window.logInfo('Hotkeys module made available on window object');
+    }
+    
     // Ensure window.debugLog is available for modules
     if (moduleRegistry.debugLog && !window.debugLog) {
       window.debugLog = moduleRegistry.debugLog;
       window.logInfo('Global debugLog made available');
+    }
+    
+    // Initialize profile state persistence
+    if (moduleRegistry.profileState) {
+      window.logInfo('🔄 Initializing profile state persistence...');
+      moduleRegistry.profileState.initializeProfileState({
+        hotkeysModule: moduleRegistry.hotkeys,
+        holdingTankModule: moduleRegistry.holdingTank
+      });
+      
+      // Load saved profile state (hotkeys + holding tank)
+      window.logInfo('📂 Loading profile state...');
+      const loadResult = await moduleRegistry.profileState.loadProfileState({
+        hotkeysModule: moduleRegistry.hotkeys,
+        holdingTankModule: moduleRegistry.holdingTank
+      });
+      
+      if (loadResult.loaded) {
+        window.logInfo('✅ Profile state restored successfully');
+      } else {
+        window.logInfo('ℹ️ No previous state found, starting fresh');
+      }
     }
     
     // Initialize function coordination system

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -97,7 +97,12 @@ import AppInitialization from './renderer/modules/app-initialization/index.js';
       }
     }
   } catch (error) {
-    console.error('Failed to load profile:', error);
+    // Use debugLog if available, fallback to console for early initialization
+    if (window.debugLog) {
+      window.debugLog.error('Failed to load profile', { error: error.message });
+    } else {
+      console.error('Failed to load profile:', error);
+    }
   }
 })();
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -86,6 +86,21 @@ import AppBootstrap from './renderer/modules/app-bootstrap/index.js';
 // Import app initialization module for centralized initialization
 import AppInitialization from './renderer/modules/app-initialization/index.js';
 
+// Load and display current profile
+(async function loadProfileIndicator() {
+  try {
+    const result = await window.secureElectronAPI.profile.getCurrent();
+    if (result.success) {
+      const profileNameElement = document.getElementById('profile-name');
+      if (profileNameElement) {
+        profileNameElement.textContent = result.profile;
+      }
+    }
+  } catch (error) {
+    console.error('Failed to load profile:', error);
+  }
+})();
+
 // Load modules dynamically and make functions globally available
 (async function loadModules() {
   try {

--- a/src/renderer/modules/app-bootstrap/module-config.js
+++ b/src/renderer/modules/app-bootstrap/module-config.js
@@ -11,6 +11,7 @@ export const moduleConfig = [
   { name: 'songManagement', path: '../song-management/index.js', required: false },
   { name: 'holdingTank', path: '../holding-tank/index.js', required: true },
   { name: 'hotkeys', path: '../hotkeys/index.js', required: false },
+  { name: 'profileState', path: '../profile-state/index.js', required: false },
   { name: 'categories', path: '../categories/index.js', required: false },
   { name: 'bulkOperations', path: '../bulk-operations/index.js', required: false },
   { name: 'dragDrop', path: '../drag-drop/index.js', required: false },

--- a/src/renderer/modules/app-initialization/data-preloader.js
+++ b/src/renderer/modules/app-initialization/data-preloader.js
@@ -21,11 +21,13 @@ export class DataPreloader {
     try {
       this.logInfo('Starting initial data loading...');
       
-      // Clear holding tank store to ensure we load new HTML
-      await this.clearHoldingTankStore();
+      // NOTE: clearHoldingTankStore() disabled for profile state management
+      // Profile state will restore holding tank content automatically
+      // await this.clearHoldingTankStore();
       
-      // Load hotkeys data
-      await this.loadHotkeys();
+      // NOTE: loadHotkeys() disabled for profile state management  
+      // Profile state will restore hotkey content automatically
+      // await this.loadHotkeys();
       
       // Load column order
       await this.loadColumnOrder();

--- a/src/renderer/modules/preferences/preference-manager.js
+++ b/src/renderer/modules/preferences/preference-manager.js
@@ -6,6 +6,8 @@
  * @module preference-manager
  */
 
+import { getPreference, setPreference } from './profile-preference-adapter.js';
+
 /**
  * Initialize the preference manager
  * @param {Object} options - Configuration options
@@ -34,17 +36,17 @@ function initializePreferenceManager(options = {}) {
    * Loads all stored preferences and populates the preferences modal
    */
   async function loadPreferences() {
-    // Use new store API for loading preferences
+    // Use adapter for loading preferences (routes to profile or global as appropriate)
     if (electronAPI && electronAPI.store) {
       try {
         const [dbDir, musicDir, hotkeyDir, fadeSeconds, debugLogPref, prereleasePref, screenModePref] = await Promise.all([
-          electronAPI.store.get("database_directory"),
-          electronAPI.store.get("music_directory"),
-          electronAPI.store.get("hotkey_directory"),
-          electronAPI.store.get("fade_out_seconds"),
-          electronAPI.store.get("debug_log_enabled"),
-          electronAPI.store.get("prerelease_updates"),
-          electronAPI.store.get("screen_mode")
+          getPreference("database_directory", electronAPI),
+          getPreference("music_directory", electronAPI),
+          getPreference("hotkey_directory", electronAPI),
+          getPreference("fade_out_seconds", electronAPI),
+          getPreference("debug_log_enabled", electronAPI),
+          getPreference("prerelease_updates", electronAPI),
+          getPreference("screen_mode", electronAPI)
         ]);
         
         if (dbDir.success) { const el = document.getElementById('preferences-database-directory'); if (el) el.value = dbDir.value || ''; }
@@ -76,7 +78,7 @@ function initializePreferenceManager(options = {}) {
   async function getDatabaseDirectory() {
     if (electronAPI && electronAPI.store) {
       try {
-        const result = await electronAPI.store.get("database_directory");
+        const result = await getPreference("database_directory", electronAPI);
         if (result.success) {
           return result.value;
         } else {
@@ -103,7 +105,7 @@ function initializePreferenceManager(options = {}) {
   async function getMusicDirectory() {
     if (electronAPI && electronAPI.store) {
       try {
-        const result = await electronAPI.store.get("music_directory");
+        const result = await getPreference("music_directory", electronAPI);
         if (result.success) {
           return result.value;
         } else {
@@ -130,7 +132,7 @@ function initializePreferenceManager(options = {}) {
   async function getHotkeyDirectory() {
     if (electronAPI && electronAPI.store) {
       try {
-        const result = await electronAPI.store.get("hotkey_directory");
+        const result = await getPreference("hotkey_directory", electronAPI);
         if (result.success) {
           return result.value;
         } else {
@@ -157,7 +159,7 @@ function initializePreferenceManager(options = {}) {
   async function getFadeOutSeconds() {
     if (electronAPI && electronAPI.store) {
       try {
-        const result = await electronAPI.store.get("fade_out_seconds");
+        const result = await getPreference("fade_out_seconds", electronAPI);
         if (result.success) {
           return result.value;
         } else {
@@ -184,7 +186,7 @@ function initializePreferenceManager(options = {}) {
   async function getDebugLogEnabled() {
     if (electronAPI && electronAPI.store) {
       try {
-        const result = await electronAPI.store.get("debug_log_enabled");
+        const result = await getPreference("debug_log_enabled", electronAPI);
         if (result.success) {
           return result.value || false;
         } else {
@@ -211,7 +213,7 @@ function initializePreferenceManager(options = {}) {
   async function getPrereleaseUpdates() {
     if (electronAPI && electronAPI.store) {
       try {
-        const result = await electronAPI.store.get("prerelease_updates");
+        const result = await getPreference("prerelease_updates", electronAPI);
         if (result.success) {
           return result.value || false;
         } else {
@@ -238,7 +240,7 @@ function initializePreferenceManager(options = {}) {
   async function getScreenMode() {
     if (electronAPI && electronAPI.store) {
       try {
-        const result = await electronAPI.store.get("screen_mode");
+        const result = await getPreference("screen_mode", electronAPI);
         if (result.success) {
           return result.value || 'auto';
         } else {

--- a/src/renderer/modules/preferences/preference-manager.js
+++ b/src/renderer/modules/preferences/preference-manager.js
@@ -20,15 +20,24 @@ function initializePreferenceManager(options = {}) {
   // Prefer exposed API; fallback to secure API if only that exists
   const electronAPISource = (typeof window !== 'undefined' && (window.electronAPI || window.secureElectronAPI)) || null;
   const electronAPI = options.electronAPI || electronAPISource;
+  const debugLog = typeof window !== 'undefined' ? window.debugLog : null;
   
   /**
    * Open the preferences modal
    * Shows the preferences dialog for user configuration
    */
-  function openPreferencesModal() {
+  async function openPreferencesModal() {
     try {
-      import('../ui/bootstrap-adapter.js').then(({ showModal }) => showModal('#preferencesModal'));
-    } catch {}
+      // Load preferences first, then show modal
+      await loadPreferences();
+      const { showModal } = await import('../ui/bootstrap-adapter.js');
+      showModal('#preferencesModal');
+    } catch (error) {
+      debugLog?.error('Failed to open preferences modal', {
+        function: 'openPreferencesModal',
+        error: error.message
+      });
+    }
   }
   
   /**
@@ -36,32 +45,91 @@ function initializePreferenceManager(options = {}) {
    * Loads all stored preferences and populates the preferences modal
    */
   async function loadPreferences() {
+    // Get the current electronAPI (may have been set after initialization)
+    const currentAPI = electronAPI || (typeof window !== 'undefined' && (window.electronAPI || window.secureElectronAPI));
+    
+    debugLog?.info('[PREFS-LOAD] Current API status', {
+      function: 'loadPreferences',
+      hasCurrentAPI: !!currentAPI,
+      hasStore: !!(currentAPI && currentAPI.store),
+      hasProfile: !!(currentAPI && currentAPI.profile),
+      apiKeys: currentAPI ? Object.keys(currentAPI) : []
+    });
+    
     // Use adapter for loading preferences (routes to profile or global as appropriate)
-    if (electronAPI && electronAPI.store) {
+    if (currentAPI && currentAPI.store) {
       try {
         const [dbDir, musicDir, hotkeyDir, fadeSeconds, debugLogPref, prereleasePref, screenModePref] = await Promise.all([
-          getPreference("database_directory", electronAPI),
-          getPreference("music_directory", electronAPI),
-          getPreference("hotkey_directory", electronAPI),
-          getPreference("fade_out_seconds", electronAPI),
-          getPreference("debug_log_enabled", electronAPI),
-          getPreference("prerelease_updates", electronAPI),
-          getPreference("screen_mode", electronAPI)
+          getPreference("database_directory", currentAPI),
+          getPreference("music_directory", currentAPI),
+          getPreference("hotkey_directory", currentAPI),
+          getPreference("fade_out_seconds", currentAPI),
+          getPreference("debug_log_enabled", currentAPI),
+          getPreference("prerelease_updates", currentAPI),
+          getPreference("screen_mode", currentAPI)
         ]);
         
-        if (dbDir.success) { const el = document.getElementById('preferences-database-directory'); if (el) el.value = dbDir.value || ''; }
-        if (musicDir.success) { const el = document.getElementById('preferences-song-directory'); if (el) el.value = musicDir.value || ''; }
-        if (hotkeyDir.success) { const el = document.getElementById('preferences-hotkey-directory'); if (el) el.value = hotkeyDir.value || ''; }
+        debugLog?.info('[PREFS-LOAD] Loaded preferences', {
+          function: 'loadPreferences',
+          dbDir: dbDir,
+          musicDir: musicDir,
+          hotkeyDir: hotkeyDir
+        });
+        
+        if (dbDir.success) { 
+          const el = document.getElementById('preferences-database-directory'); 
+          if (el) {
+            el.value = dbDir.value || ''; 
+            debugLog?.info('[PREFS-LOAD] Set database directory field', {
+              elementFound: !!el,
+              value: dbDir.value,
+              finalValue: el.value
+            });
+          }
+        }
+        if (musicDir.success) { 
+          const el = document.getElementById('preferences-song-directory'); 
+          if (el) {
+            el.value = musicDir.value || ''; 
+            debugLog?.info('[PREFS-LOAD] Set music directory field', {
+              elementFound: !!el,
+              value: musicDir.value,
+              finalValue: el.value
+            });
+          }
+        }
+        if (hotkeyDir.success) { 
+          const el = document.getElementById('preferences-hotkey-directory'); 
+          if (el) {
+            el.value = hotkeyDir.value || ''; 
+            debugLog?.info('[PREFS-LOAD] Set hotkey directory field', {
+              elementFound: !!el,
+              value: hotkeyDir.value,
+              finalValue: el.value
+            });
+          }
+        }
         if (fadeSeconds.success) { const el = document.getElementById('preferences-fadeout-seconds'); if (el) el.value = fadeSeconds.value || ''; }
         if (debugLogPref.success) { const el = document.getElementById('preferences-debug-log-enabled'); if (el) el.checked = !!debugLogPref.value; }
         if (prereleasePref.success) { const el = document.getElementById('preferences-prerelease-updates'); if (el) el.checked = !!prereleasePref.value; }
         if (screenModePref.success) { const el = document.getElementById('preferences-screen-mode'); if (el) el.value = screenModePref.value || 'auto'; }
       } catch (error) {
-        await debugLog.error('Failed to load preferences', { 
+        debugLog?.error('Failed to load preferences', { 
           function: "loadPreferences",
-          error: error
+          error: error.message,
+          stack: error.stack
         });
       }
+    } else {
+      debugLog?.error('Cannot load preferences - electronAPI not available', {
+        function: 'loadPreferences',
+        hasElectronAPI: !!currentAPI,
+        hasStore: !!(currentAPI && currentAPI.store),
+        windowAPI: typeof window !== 'undefined' ? {
+          hasElectronAPI: !!window.electronAPI,
+          hasSecureAPI: !!window.secureElectronAPI
+        } : 'window not available'
+      });
     }
   }
   

--- a/src/renderer/modules/preferences/profile-preference-adapter.js
+++ b/src/renderer/modules/preferences/profile-preference-adapter.js
@@ -1,0 +1,82 @@
+/**
+ * Profile Preference Adapter
+ * 
+ * Routes preference get/set operations to either:
+ * - Profile-specific preferences (theme, font, column order, etc.)
+ * - Global preferences (directories)
+ */
+
+const GLOBAL_PREFERENCES = [
+  'database_directory',
+  'music_directory',
+  'hotkey_directory'
+];
+
+const PROFILE_PREFERENCES = [
+  'screen_mode',
+  'font_size',
+  'column_order',
+  'fade_out_seconds',
+  'debug_log_enabled',
+  'prerelease_updates',
+  'holding_tank_mode'
+];
+
+/**
+ * Get a preference value
+ * @param {string} key - Preference key
+ * @param {Object} electronAPI - Electron API object
+ * @returns {Promise<{success: boolean, value: any}>}
+ */
+export async function getPreference(key, electronAPI) {
+  if (GLOBAL_PREFERENCES.includes(key)) {
+    // Use global store for directories
+    return await electronAPI.store.get(key);
+  } else if (PROFILE_PREFERENCES.includes(key)) {
+    // Use profile preferences
+    return await electronAPI.profile.getPreference(key);
+  } else {
+    // Unknown preference, try global store as fallback
+    console.warn(`Unknown preference key: ${key}, using global store`);
+    return await electronAPI.store.get(key);
+  }
+}
+
+/**
+ * Set a preference value
+ * @param {string} key - Preference key
+ * @param {any} value - Preference value
+ * @param {Object} electronAPI - Electron API object
+ * @returns {Promise<{success: boolean}>}
+ */
+export async function setPreference(key, value, electronAPI) {
+  if (GLOBAL_PREFERENCES.includes(key)) {
+    // Use global store for directories
+    return await electronAPI.store.set(key, value);
+  } else if (PROFILE_PREFERENCES.includes(key)) {
+    // Use profile preferences
+    return await electronAPI.profile.setPreference(key, value);
+  } else {
+    // Unknown preference, try global store as fallback
+    console.warn(`Unknown preference key: ${key}, using global store`);
+    return await electronAPI.store.set(key, value);
+  }
+}
+
+/**
+ * Get all profile-specific preferences
+ * @param {Object} electronAPI - Electron API object
+ * @returns {Promise<{success: boolean, preferences: Object}>}
+ */
+export async function getAllProfilePreferences(electronAPI) {
+  return await electronAPI.profile.getAllPreferences();
+}
+
+export default {
+  getPreference,
+  setPreference,
+  getAllProfilePreferences,
+  GLOBAL_PREFERENCES,
+  PROFILE_PREFERENCES
+};
+

--- a/src/renderer/modules/preferences/settings-controller.js
+++ b/src/renderer/modules/preferences/settings-controller.js
@@ -74,7 +74,7 @@ function initializeSettingsController(options = {}) {
         database_directory: dbDir || currentDbDir,
         music_directory: musicDir || currentMusicDir,
         hotkey_directory: hotkeyDir || currentHotkeyDir,
-        fade_out_seconds: (document.getElementById('preferences-fadeout-seconds')?.value) || '',
+        fade_out_seconds: parseInt(document.getElementById('preferences-fadeout-seconds')?.value) || 3,
         debug_log_enabled: !!document.getElementById('preferences-debug-log-enabled')?.checked,
         prerelease_updates: !!document.getElementById('preferences-prerelease-updates')?.checked,
         screen_mode: (document.getElementById('preferences-screen-mode')?.value) || 'auto'

--- a/src/renderer/modules/preferences/settings-controller.js
+++ b/src/renderer/modules/preferences/settings-controller.js
@@ -6,6 +6,8 @@
  * @module settings-controller
  */
 
+import { setPreference } from './profile-preference-adapter.js';
+
 // Import debug logger from global scope (renderer initializes it early)
 let debugLog = null;
 try {
@@ -59,16 +61,16 @@ function initializeSettingsController(options = {}) {
         screen_mode: (document.getElementById('preferences-screen-mode')?.value) || 'auto'
       };
       
-      // Save all preferences
+      // Save all preferences (using adapter to route to profile or global as appropriate)
       try {
         const results = await Promise.all([
-          electronAPI.store.set("database_directory", preferences.database_directory),
-          electronAPI.store.set("music_directory", preferences.music_directory),
-          electronAPI.store.set("hotkey_directory", preferences.hotkey_directory),
-          electronAPI.store.set("fade_out_seconds", preferences.fade_out_seconds),
-          electronAPI.store.set("debug_log_enabled", preferences.debug_log_enabled),
-          electronAPI.store.set("prerelease_updates", preferences.prerelease_updates),
-          electronAPI.store.set("screen_mode", preferences.screen_mode)
+          setPreference("database_directory", preferences.database_directory, electronAPI),
+          setPreference("music_directory", preferences.music_directory, electronAPI),
+          setPreference("hotkey_directory", preferences.hotkey_directory, electronAPI),
+          setPreference("fade_out_seconds", preferences.fade_out_seconds, electronAPI),
+          setPreference("debug_log_enabled", preferences.debug_log_enabled, electronAPI),
+          setPreference("prerelease_updates", preferences.prerelease_updates, electronAPI),
+          setPreference("screen_mode", preferences.screen_mode, electronAPI)
         ]);
         
         const successCount = results.filter(result => result.success).length;

--- a/src/renderer/modules/profile-state/index.js
+++ b/src/renderer/modules/profile-state/index.js
@@ -1,0 +1,588 @@
+/**
+ * Profile State Persistence Module
+ * 
+ * Automatically saves and restores profile-specific UI state:
+ * - All hotkey tabs (song IDs + custom tab names)
+ * - All holding tank tabs (song IDs + custom tab names)
+ * 
+ * State is saved to profile directory as state.json
+ * Loaded on app start and saved on quit/profile switch
+ */
+
+let debugLog = null;
+try {
+  if (window.debugLog) {
+    debugLog = window.debugLog;
+  }
+} catch (error) {
+  // Debug logger not available
+}
+
+// Store module references for auto-save
+let hotkeysModuleRef = null;
+let holdingTankModuleRef = null;
+
+/**
+ * Extract all hotkey tabs state
+ * @returns {Array} Array of hotkey tab states
+ */
+function extractHotkeyTabs() {
+  const tabs = [];
+  
+  // Iterate through all 5 hotkey tabs
+  for (let tabNum = 1; tabNum <= 5; tabNum++) {
+    const tabContent = document.getElementById(`hotkeys_list_${tabNum}`);
+    const tabLink = document.querySelector(`#hotkey_tabs .nav-item:nth-child(${tabNum}) a`);
+    
+    if (!tabContent || !tabLink) continue;
+    
+    const hotkeys = {};
+    let hasData = false;
+    
+    // Extract all 12 hotkeys from this tab
+    for (let key = 1; key <= 12; key++) {
+      const element = tabContent.querySelector(`#f${key}_hotkey`);
+      if (element) {
+        const songId = element.getAttribute('songid');
+        if (songId) {
+          hotkeys[`f${key}`] = songId;
+          hasData = true;
+        }
+      }
+    }
+    
+    // Get tab name (if customized, otherwise it's just the number)
+    const tabName = tabLink.textContent.trim();
+    const isCustomName = !/^\d$/.test(tabName); // Not just a number
+    
+    tabs.push({
+      tabNumber: tabNum,
+      tabName: isCustomName ? tabName : null,
+      hotkeys: hasData ? hotkeys : {}
+    });
+  }
+  
+  return tabs;
+}
+
+/**
+ * Extract all holding tank tabs state
+ * @returns {Array} Array of holding tank tab states
+ */
+function extractHoldingTankTabs() {
+  const tabs = [];
+  
+  // Iterate through all 5 holding tank tabs
+  for (let tabNum = 1; tabNum <= 5; tabNum++) {
+    const tabContent = document.getElementById(`holding_tank_${tabNum}`);
+    const tabLink = document.querySelector(`#holding_tank_tabs .nav-item:nth-child(${tabNum}) a`);
+    
+    if (!tabContent || !tabLink) {
+      debugLog?.warn('[PROFILE-STATE] Missing holding tank tab elements', {
+        module: 'profile-state',
+        function: 'extractHoldingTankTabs',
+        tabNum: tabNum,
+        hasContent: !!tabContent,
+        hasLink: !!tabLink
+      });
+      continue;
+    }
+    
+    const songIds = [];
+    
+    // Extract all songs from this tab
+    const songElements = tabContent.querySelectorAll('li.list-group-item[songid]');
+    
+    debugLog?.info('[PROFILE-STATE] Extracting holding tank tab', {
+      module: 'profile-state',
+      function: 'extractHoldingTankTabs',
+      tabNum: tabNum,
+      songCount: songElements.length,
+      contentId: tabContent.id
+    });
+    
+    songElements.forEach(element => {
+      const songId = element.getAttribute('songid');
+      if (songId) {
+        songIds.push(songId);
+      }
+    });
+    
+    // Get tab name (if customized)
+    const tabName = tabLink.textContent.trim();
+    const isCustomName = !/^\d$/.test(tabName);
+    
+    tabs.push({
+      tabNumber: tabNum,
+      tabName: isCustomName ? tabName : null,
+      songIds: songIds
+    });
+  }
+  
+  return tabs;
+}
+
+/**
+ * Extract complete profile state
+ * @returns {Object} Complete state object
+ */
+export function extractProfileState() {
+  const state = {
+    version: '1.0.0',
+    timestamp: Date.now(),
+    hotkeys: extractHotkeyTabs(),
+    holdingTank: extractHoldingTankTabs()
+  };
+  
+  debugLog?.info('[PROFILE-STATE] Extracted profile state', { 
+    module: 'profile-state',
+    function: 'extractProfileState',
+    hotkeyTabs: state.hotkeys.length,
+    holdingTankTabs: state.holdingTank.length
+  });
+  
+  return state;
+}
+
+/**
+ * Save profile state to file
+ * @returns {Promise<Object>} Result with success status
+ */
+export async function saveProfileState() {
+  try {
+    const state = extractProfileState();
+    
+    // Get profile-specific directory
+    const result = await window.secureElectronAPI.profile.getDirectory('state');
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to get profile directory');
+    }
+    
+    const stateDir = result.directory;
+    const stateFileResult = await window.secureElectronAPI.path.join(stateDir, 'state.json');
+    const stateFile = stateFileResult.success ? stateFileResult.data : null;
+    
+    if (!stateFile) {
+      throw new Error('Failed to build state file path');
+    }
+    
+    // Ensure directory exists
+    await window.secureElectronAPI.fileSystem.mkdir(stateDir);
+    
+    // Write state file
+    const writeResult = await window.secureElectronAPI.fileSystem.write(
+      stateFile,
+      JSON.stringify(state, null, 2)
+    );
+    
+    if (writeResult.success) {
+      debugLog?.info('[PROFILE-STATE] Profile state saved successfully', { 
+        module: 'profile-state',
+        function: 'saveProfileState',
+        stateFile: stateFile
+      });
+      return { success: true };
+    } else {
+      throw new Error(writeResult.error || 'Failed to write state file');
+    }
+  } catch (error) {
+    debugLog?.error('[PROFILE-STATE] Failed to save profile state', { 
+      module: 'profile-state',
+      function: 'saveProfileState',
+      error: error.message
+    });
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Restore hotkey tabs from state
+ * @param {Array} hotkeyTabs - Array of hotkey tab states
+ * @param {Object} hotkeysModule - Hotkeys module instance
+ * @returns {Promise<void>}
+ */
+async function restoreHotkeyTabs(hotkeyTabs, hotkeysModule) {
+  debugLog?.info('[PROFILE-STATE] restoreHotkeyTabs called', {
+    module: 'profile-state',
+    function: 'restoreHotkeyTabs',
+    tabCount: hotkeyTabs?.length || 0
+  });
+  
+  if (!hotkeyTabs || !Array.isArray(hotkeyTabs)) {
+    debugLog?.warn('[PROFILE-STATE] Invalid hotkey tabs data', {
+      module: 'profile-state',
+      function: 'restoreHotkeyTabs'
+    });
+    return;
+  }
+  
+  for (const tabState of hotkeyTabs) {
+    const { tabNumber, tabName, hotkeys } = tabState;
+    
+    if (!hotkeys || Object.keys(hotkeys).length === 0) {
+      debugLog?.info('[PROFILE-STATE] Skipping empty hotkey tab', {
+        module: 'profile-state',
+        function: 'restoreHotkeyTabs',
+        tabNumber: tabNumber,
+        tabName: tabName
+      });
+      continue;
+    }
+    
+    debugLog?.info('[PROFILE-STATE] Restoring hotkey tab', {
+      module: 'profile-state',
+      function: 'restoreHotkeyTabs',
+      tabNumber: tabNumber,
+      tabName: tabName,
+      hotkeyCount: Object.keys(hotkeys).length
+    });
+    
+    // Switch to this tab
+    const tabLink = document.querySelector(`#hotkey_tabs .nav-item:nth-child(${tabNumber}) a`);
+    if (tabLink) {
+      tabLink.click();
+      
+      // Wait a bit for tab to activate
+      await new Promise(resolve => setTimeout(resolve, 50));
+      
+      // Set custom tab name if exists
+      if (tabName) {
+        tabLink.textContent = tabName;
+      }
+      
+      // Restore each hotkey in this tab directly (without relying on .active class)
+      for (const [key, songId] of Object.entries(hotkeys)) {
+        debugLog?.info('[PROFILE-STATE] Restoring hotkey', {
+          module: 'profile-state',
+          function: 'restoreHotkeyTabs',
+          tabNumber: tabNumber,
+          key: key,
+          songId: songId
+        });
+        try {
+          // Validate that song still exists in database and get its info
+          const songResult = await window.secureElectronAPI.database.query(
+            'SELECT * FROM mrvoice WHERE id = ?',
+            [songId]
+          );
+          
+          if (songResult.success && songResult.data && songResult.data.length > 0) {
+            const row = songResult.data[0];
+            const title = row.title || '[Unknown Title]';
+            const artist = row.artist || '[Unknown Artist]';
+            const time = row.time || '[??:??]';
+            
+            // Find the element in this specific tab (not relying on .active)
+            const tabContent = document.getElementById(`hotkeys_list_${tabNumber}`);
+            const element = tabContent?.querySelector(`#${key}_hotkey`);
+            
+            if (element) {
+              // Set the songid attribute
+              element.setAttribute('songid', songId);
+              
+              // Set the label text directly
+              const span = element.querySelector('span');
+              if (span) {
+                span.textContent = `${title} by ${artist} (${time})`;
+              }
+              
+              debugLog?.info('[PROFILE-STATE] Hotkey restored successfully', {
+                module: 'profile-state',
+                function: 'restoreHotkeyTabs',
+                tabNumber: tabNumber,
+                key: key,
+                songId: songId,
+                title: title
+              });
+            } else {
+              debugLog?.warn('[PROFILE-STATE] Hotkey element not found', {
+                module: 'profile-state',
+                function: 'restoreHotkeyTabs',
+                tabNumber: tabNumber,
+                key: key,
+                elementId: `${key}_hotkey`,
+                tabContentId: `hotkeys_list_${tabNumber}`
+              });
+            }
+          } else {
+            debugLog?.warn('[PROFILE-STATE] Skipping deleted song in hotkey restore', { 
+              module: 'profile-state',
+              function: 'restoreHotkeyTabs',
+              songId: songId,
+              key: key
+            });
+          }
+        } catch (error) {
+          debugLog?.error('[PROFILE-STATE] Error restoring hotkey', { 
+            module: 'profile-state',
+            function: 'restoreHotkeyTabs',
+            key: key,
+            songId: songId,
+            error: error.message
+          });
+        }
+      }
+    }
+  }
+  
+  // Switch back to first tab
+  const firstTab = document.querySelector('#hotkey_tabs .nav-item:first-child a');
+  if (firstTab) {
+    firstTab.click();
+  }
+  
+  debugLog?.info('[PROFILE-STATE] Hotkey restoration complete', {
+    module: 'profile-state',
+    function: 'restoreHotkeyTabs'
+  });
+}
+
+/**
+ * Restore holding tank tabs from state
+ * @param {Array} holdingTankTabs - Array of holding tank tab states
+ * @param {Object} holdingTankModule - Holding tank module instance
+ * @returns {Promise<void>}
+ */
+async function restoreHoldingTankTabs(holdingTankTabs, holdingTankModule) {
+  debugLog?.info('[PROFILE-STATE] restoreHoldingTankTabs called', {
+    module: 'profile-state',
+    function: 'restoreHoldingTankTabs',
+    tabCount: holdingTankTabs?.length || 0
+  });
+  
+  if (!holdingTankTabs || !Array.isArray(holdingTankTabs)) {
+    debugLog?.warn('[PROFILE-STATE] Invalid holding tank tabs data', {
+      module: 'profile-state',
+      function: 'restoreHoldingTankTabs'
+    });
+    return;
+  }
+  
+  for (const tabState of holdingTankTabs) {
+    const { tabNumber, tabName, songIds } = tabState;
+    
+    if (!songIds || songIds.length === 0) continue;
+    
+    // Switch to this tab
+    const tabLink = document.querySelector(`#holding_tank_tabs .nav-item:nth-child(${tabNumber}) a`);
+    if (tabLink) {
+      tabLink.click();
+      
+      // Wait a bit for tab to activate
+      await new Promise(resolve => setTimeout(resolve, 50));
+      
+      // Set custom tab name if exists
+      if (tabName) {
+        tabLink.textContent = tabName;
+      }
+      
+      // Clear current tab content
+      const tabContent = document.getElementById(`holding_tank_${tabNumber}`);
+      if (tabContent) {
+        tabContent.innerHTML = '';
+      }
+      
+      // Restore each song in order
+      for (const songId of songIds) {
+        try {
+          // Validate that song still exists in database
+          const songResult = await window.secureElectronAPI.database.query(
+            'SELECT id FROM mrvoice WHERE id = ?',
+            [songId]
+          );
+          
+          if (songResult.success && songResult.data && songResult.data.length > 0) {
+            // Use holding tank module to add the song
+            if (holdingTankModule && holdingTankModule.addToHoldingTank) {
+              await holdingTankModule.addToHoldingTank(songId, tabContent);
+            }
+          } else {
+            debugLog?.warn('[PROFILE-STATE] Skipping deleted song in holding tank restore', { 
+              module: 'profile-state',
+              function: 'restoreHoldingTankTabs',
+              songId: songId
+            });
+          }
+        } catch (error) {
+          debugLog?.error('[PROFILE-STATE] Error restoring holding tank song', { 
+            module: 'profile-state',
+            function: 'restoreHoldingTankTabs',
+            songId: songId,
+            error: error.message
+          });
+        }
+      }
+    }
+  }
+  
+  // Switch back to first tab
+  const firstTab = document.querySelector('#holding_tank_tabs .nav-item:first-child a');
+  if (firstTab) {
+    firstTab.click();
+  }
+}
+
+/**
+ * Load and restore profile state
+ * @param {Object} options - Options containing module instances
+ * @param {Object} options.hotkeysModule - Hotkeys module instance
+ * @param {Object} options.holdingTankModule - Holding tank module instance
+ * @returns {Promise<Object>} Result with success status
+ */
+export async function loadProfileState(options = {}) {
+  try {
+    const { hotkeysModule, holdingTankModule } = options;
+    
+    // Get profile-specific directory
+    const dirResult = await window.secureElectronAPI.profile.getDirectory('state');
+    if (!dirResult.success) {
+      debugLog?.info('[PROFILE-STATE] No profile directory found, skipping state load', { 
+        module: 'profile-state',
+        function: 'loadProfileState'
+      });
+      return { success: true, loaded: false };
+    }
+    
+    const stateDir = dirResult.directory;
+    const stateFileResult = await window.secureElectronAPI.path.join(stateDir, 'state.json');
+    const stateFile = stateFileResult.success ? stateFileResult.data : null;
+    
+    if (!stateFile) {
+      debugLog?.error('[PROFILE-STATE] Failed to build state file path', {
+        module: 'profile-state',
+        function: 'loadProfileState',
+        error: stateFileResult.error
+      });
+      return { success: false, error: 'Failed to build state file path' };
+    }
+    
+    // Check if state file exists
+    const existsResult = await window.secureElectronAPI.fileSystem.exists(stateFile);
+    if (!existsResult.success || !existsResult.exists) {
+      debugLog?.info('[PROFILE-STATE] No state file found, starting fresh', { 
+        module: 'profile-state',
+        function: 'loadProfileState',
+        stateFile: stateFile,
+        existsResult: existsResult
+      });
+      return { success: true, loaded: false };
+    }
+    
+    // Read state file
+    const readResult = await window.secureElectronAPI.fileSystem.read(stateFile);
+    if (!readResult.success) {
+      throw new Error(readResult.error || 'Failed to read state file');
+    }
+    
+    const state = JSON.parse(readResult.data);
+    
+    debugLog?.info('[PROFILE-STATE] Loaded profile state', { 
+      module: 'profile-state',
+      function: 'loadProfileState',
+      version: state.version,
+      timestamp: state.timestamp,
+      hotkeyTabs: state.hotkeys?.length || 0,
+      holdingTankTabs: state.holdingTank?.length || 0
+    });
+    
+    // Restore hotkeys
+    if (state.hotkeys && hotkeysModule) {
+      debugLog?.info('[PROFILE-STATE] Restoring hotkeys from state', { 
+        module: 'profile-state',
+        function: 'loadProfileState',
+        tabCount: state.hotkeys.length
+      });
+      await restoreHotkeyTabs(state.hotkeys, hotkeysModule);
+    } else {
+      debugLog?.warn('[PROFILE-STATE] Skipping hotkey restore', {
+        module: 'profile-state',
+        function: 'loadProfileState',
+        hasHotkeys: !!state.hotkeys,
+        hasModule: !!hotkeysModule
+      });
+    }
+    
+    // Restore holding tank
+    if (state.holdingTank && holdingTankModule) {
+      debugLog?.info('[PROFILE-STATE] Restoring holding tank from state', { 
+        module: 'profile-state',
+        function: 'loadProfileState',
+        tabCount: state.holdingTank.length
+      });
+      await restoreHoldingTankTabs(state.holdingTank, holdingTankModule);
+    } else {
+      debugLog?.warn('[PROFILE-STATE] Skipping holding tank restore', {
+        module: 'profile-state',
+        function: 'loadProfileState',
+        hasHoldingTank: !!state.holdingTank,
+        hasModule: !!holdingTankModule
+      });
+    }
+    
+    debugLog?.info('[PROFILE-STATE] Profile state restoration complete', {
+      module: 'profile-state',
+      function: 'loadProfileState'
+    });
+    
+    return { success: true, loaded: true };
+  } catch (error) {
+    debugLog?.error('[PROFILE-STATE] Failed to load profile state', { 
+      module: 'profile-state',
+      function: 'loadProfileState',
+      error: error.message
+    });
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Initialize profile state persistence
+ * Sets up auto-save on window close
+ * @param {Object} options - Initialization options
+ * @param {Object} options.hotkeysModule - Reference to hotkeys module
+ * @param {Object} options.holdingTankModule - Reference to holding tank module
+ * @returns {Object} Module interface
+ */
+export function initializeProfileState({ hotkeysModule, holdingTankModule } = {}) {
+  debugLog?.info('[PROFILE-STATE] Initializing profile state persistence', { 
+    module: 'profile-state',
+    function: 'initializeProfileState'
+  });
+  
+  // Store module references for auto-save
+  if (hotkeysModule) hotkeysModuleRef = hotkeysModule;
+  if (holdingTankModule) holdingTankModuleRef = holdingTankModule;
+  
+  // Save state before window closes
+  window.addEventListener('beforeunload', (event) => {
+    debugLog?.info('[PROFILE-STATE] Window closing, saving profile state', { 
+      module: 'profile-state',
+      function: 'beforeunload'
+    });
+    
+    // Extract state immediately (synchronous)
+    const state = extractProfileState();
+    
+    // Send to main process for saving (fire and forget)
+    // The main process will handle the actual file write
+    if (window.secureElectronAPI && window.secureElectronAPI.profile) {
+      window.secureElectronAPI.profile.saveState(state).catch(err => {
+        console.error('Failed to save state on quit:', err);
+      });
+    }
+  });
+  
+  return {
+    extractProfileState,
+    saveProfileState,
+    loadProfileState
+  };
+}
+
+export default {
+  initializeProfileState,
+  extractProfileState,
+  saveProfileState,
+  loadProfileState
+};
+

--- a/src/renderer/modules/profile-state/index.js
+++ b/src/renderer/modules/profile-state/index.js
@@ -567,7 +567,11 @@ export function initializeProfileState({ hotkeysModule, holdingTankModule } = {}
     // The main process will handle the actual file write
     if (window.secureElectronAPI && window.secureElectronAPI.profile) {
       window.secureElectronAPI.profile.saveState(state).catch(err => {
-        console.error('Failed to save state on quit:', err);
+        debugLog?.error('[PROFILE-STATE] Failed to save state on quit', { 
+          module: 'profile-state',
+          function: 'beforeunload',
+          error: err.message 
+        });
       });
     }
   });

--- a/src/stylesheets/index.css
+++ b/src/stylesheets/index.css
@@ -918,3 +918,28 @@ legend {
   border: 1.5px solid #0078d7 !important;
   color: #fff !important;
 }
+
+/* Profile indicator styles */
+.profile-indicator {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  font-size: 11px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--card-header-bg);
+}
+
+.profile-indicator i {
+  font-size: 10px;
+}
+
+.profile-indicator:hover {
+  color: var(--text-color);
+  background: var(--hover-bg);
+}
+/* End profile indicator styles */


### PR DESCRIPTION
## Overview

This PR implements a complete multi-profile system with a dedicated launcher window, replacing the previous in-app profile switching approach. The new architecture cleanly separates profile management from the main application, allowing each profile to run in complete isolation.

## Architecture Changes

### Launcher Window
- New profile launcher window (`src/launcher.html`, `src/launcher.js`) shown on app startup
- Profile selection/creation/deletion before main app launch
- Dark mode support with CSS custom properties and system theme detection
- Profile management UI with create/delete functionality using modal dialogs

### Profile Context Isolation
- Main app launches with `--profile="ProfileName"` command-line argument
- Each profile runs in complete isolation - unaware of other profiles
- Profile data stored in `~/Library/Application Support/Mx. Voice/profiles/{ProfileName}/`
- Profile switching closes current window and relaunches with new profile context

### State Persistence
- **Auto-save/restore**: Automatically saves all hotkey tabs and holding tank tabs on quit/profile switch
- **Structured data storage**: Stores song IDs and tab metadata in `state.json` (not HTML)
- **Deleted song handling**: Skips restoration of songs that no longer exist in database
- **Custom tab names**: Preserves user-customized tab names across sessions

### Per-Profile Preferences
Profile-specific preferences (stored in `profiles/{ProfileName}/preferences.json`):
- `screen_mode` (light/dark/auto)
- `font_size`
- `column_order`
- `fade_out_seconds` (default: 3)
- `debug_log_enabled`
- `prerelease_updates`
- `holding_tank_mode`

Global preferences (shared across all profiles in `config.json`):
- `database_directory`
- `music_directory`
- `hotkey_directory`

### Preference Migration
- Automatic migration of existing global settings to Default User profile on first launch
- Migration tracking with metadata (`_migrated`, `_migration_date`, `_migrated_count`)
- Cleanup of deprecated preference keys during load
- Unwrapping of corrupted nested preference objects

## Key Files Added/Modified

### New Files
- `src/launcher.html` - Profile launcher UI
- `src/launcher.js` - Launcher window logic
- `src/preload/launcher-preload.js` - Preload script for launcher (CommonJS)
- `src/main/modules/launcher-window.js` - Launcher window management
- `src/main/modules/profile-manager.js` - Profile CRUD and preference management
- `src/renderer/modules/profile-state/` - State persistence module
- `src/renderer/modules/preferences/profile-preference-adapter.js` - Preference routing logic

### Modified Files
- `src/main/index-modular.js` - Profile argument handling and launcher integration
- `src/main/modules/ipc-handlers.js` - New IPC handlers for profile operations
- `src/preload/modules/secure-api-exposer.js` - Profile API exposure
- `src/renderer/modules/preferences/` - Updated to use profile-aware adapter
- `src/renderer/modules/app-initialization/data-preloader.js` - Profile state loading
- `src/index.html` - Info alert for shared directory preferences

## Features

### Profile Management
- ✅ Create new profiles with names and descriptions
- ✅ Delete profiles (with confirmation, cannot delete last profile)
- ✅ Profile registry stored in `profiles.json`
- ✅ Profile indicator in main app UI (top-right of search column)
- ✅ Profile switching via menu (closes and relaunches app)

### State Persistence
- ✅ All 5 hotkey tabs preserved (song assignments and custom names)
- ✅ All 5 holding tank tabs preserved (song lists and custom names)
- ✅ Automatic save on window close, app quit, and profile switch
- ✅ Automatic restore on profile launch
- ✅ Graceful handling of missing songs (skipped during restore)

### Preferences
- ✅ Per-profile UI preferences (theme, font, column order, etc.)
- ✅ Global directory preferences (database, music, hotkeys)
- ✅ Clear UI indication that directories are shared across profiles
- ✅ Validation to prevent accidental clearing of directory paths
- ✅ Migration of existing user preferences to default profile

### UI/UX
- ✅ Dark mode support in launcher matching profile theme preference
- ✅ Profile name displayed in main app
- ✅ Bootstrap modal for profile creation (no `prompt()` calls)
- ✅ Graceful error handling and user feedback
- ✅ Info alert in preferences explaining shared directories

## Bug Fixes

- Fixed `prompt()` not supported in Electron (replaced with modal)
- Fixed holding tank DOM selector (was using wrong ID)
- Fixed async file operations in `beforeunload` handler
- Fixed hotkey restoration failing for non-active tabs
- Fixed column order not saving/loading correctly
- Fixed preferences being cleared on save (empty directory validation)
- Fixed nested preference object corruption with `unwrapValue()`
- Fixed `electronAPI.profile` undefined during early initialization (graceful fallback)
- Fixed launcher dark mode colors and button visibility
- Fixed UI jumping on hover (removed `transform` animations)
- Fixed theme not applying when preferences saved
- Fixed fade out seconds default (changed from 2 to 3)

## Testing Recommendations

Before merging, please test:
1. ✅ Fresh install → profile creation → directory setup
2. ✅ Existing user migration → global settings copied to default profile
3. ✅ Profile switching → state restored correctly
4. ✅ Directory preferences remain global across profile switches
5. ✅ Hotkey/holding tank auto-save/restore with custom tab names
6. ✅ Theme changes per-profile
7. ✅ Column order per-profile

## Breaking Changes

⚠️ **User Impact**: Existing users will see a profile launcher on first run. Their current settings will be migrated to a "Default User" profile automatically.

## Migration Path

For existing users:
1. On first launch, launcher window appears
2. If no profiles exist, "Default User" profile is auto-created
3. Global preferences (theme, font, etc.) are migrated to Default User profile
4. User can continue with Default User or create additional profiles
5. Global directory preferences (`database_directory`, `music_directory`, `hotkey_directory`) remain unchanged

## Notes

- Profile data location: `~/Library/Application Support/Mx. Voice/profiles/`
- Profile registry: `~/Library/Application Support/Mx. Voice/profiles.json`
- State file per profile: `profiles/{ProfileName}/state.json`
- Preferences per profile: `profiles/{ProfileName}/preferences.json`

## Related Issues

Closes the issues with the previous `user-profiles` branch where the app struggled to maintain profile context within a fundamentally single-profile system.